### PR TITLE
feat(detail): 作品詳細画面の実装

### DIFF
--- a/Sources/Features/AuthorDetail/View/AuthorDetailScreen.swift
+++ b/Sources/Features/AuthorDetail/View/AuthorDetailScreen.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+struct AuthorDetailScreen: View {
+    let person: Person
+
+    var body: some View {
+        Text(person.fullName)
+            .navigationTitle("著者詳細")
+    }
+}

--- a/Sources/Features/Reader/View/ReaderScreen.swift
+++ b/Sources/Features/Reader/View/ReaderScreen.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+struct ReaderScreen: View {
+    let book: Book
+
+    var body: some View {
+        Text("読書画面（実装予定）")
+            .navigationTitle(book.title)
+    }
+}

--- a/Sources/Features/WorkDetail/View/WorkDetailScreen.swift
+++ b/Sources/Features/WorkDetail/View/WorkDetailScreen.swift
@@ -2,9 +2,109 @@ import SwiftUI
 
 struct WorkDetailScreen: View {
     let book: Book
+    @State private var viewModel: WorkDetailViewModel
+
+    init(book: Book) {
+        self.book = book
+        _viewModel = State(initialValue: WorkDetailViewModel(book: book))
+    }
 
     var body: some View {
-        Text(book.title)
-            .navigationTitle("作品詳細")
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                headerSection
+                metadataSection
+                actionSection
+            }
+            .padding()
+        }
+        .navigationTitle("作品詳細")
+        .navigationBarTitleDisplayMode(.inline)
+        .task { await viewModel.loadAuthor() }
+    }
+
+    @ViewBuilder
+    private var headerSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(book.title)
+                .font(.title)
+                .fontWeight(.bold)
+
+            if !book.subtitle.isEmpty {
+                Text(book.subtitle)
+                    .font(.title3)
+                    .foregroundStyle(.secondary)
+            }
+
+            if let author = viewModel.author {
+                NavigationLink {
+                    AuthorDetailScreen(person: author)
+                } label: {
+                    Label(author.fullName, systemImage: "person")
+                        .font(.headline)
+                }
+            } else {
+                Label(book.authorName, systemImage: "person")
+                    .font(.headline)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var metadataSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            if !book.classification.isEmpty {
+                MetadataRow(label: "分類", value: book.classification)
+            }
+
+            if !book.releaseDate.isEmpty {
+                MetadataRow(label: "公開日", value: book.releaseDate)
+            }
+
+            if let url = book.cardURL {
+                HStack {
+                    Text("図書カード")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Link("青空文庫で見る", destination: url)
+                        .font(.subheadline)
+                }
+            }
+        }
+        .padding()
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+    }
+
+    @ViewBuilder
+    private var actionSection: some View {
+        NavigationLink {
+            ReaderScreen(book: book)
+        } label: {
+            Label("この作品を読む", systemImage: "book")
+                .font(.headline)
+                .frame(maxWidth: .infinity)
+                .padding()
+                .background(.blue)
+                .foregroundStyle(.white)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+        }
+    }
+}
+
+private struct MetadataRow: View {
+    let label: String
+    let value: String
+
+    var body: some View {
+        HStack {
+            Text(label)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            Spacer()
+            Text(value)
+                .font(.subheadline)
+        }
     }
 }

--- a/Sources/Features/WorkDetail/ViewModel/WorkDetailViewModel.swift
+++ b/Sources/Features/WorkDetail/ViewModel/WorkDetailViewModel.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+@Observable
+@MainActor
+final class WorkDetailViewModel {
+    let book: Book
+    var author: Person?
+    var isLoading = false
+    var errorMessage: String?
+
+    private let catalogService = CatalogService.shared
+
+    init(book: Book) {
+        self.book = book
+    }
+
+    func loadAuthor() async {
+        isLoading = true
+        do {
+            author = try await catalogService.person(id: book.personId)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isLoading = false
+    }
+}


### PR DESCRIPTION
## Summary
- WorkDetailScreen: タイトル・副題・著者・分類・公開日・図書カードリンクを表示
- WorkDetailViewModel: 著者情報をカタログから非同期取得
- 著者タップで AuthorDetailScreen（スタブ）へ遷移
- 「読む」ボタンで ReaderScreen（スタブ）へ遷移

## Test plan
- [ ] 検索結果から作品をタップすると詳細が表示される
- [ ] タイトル・著者・分類・公開日が正しく表示される
- [ ] 著者名タップで著者詳細スタブに遷移する
- [ ] 「読む」ボタンで読書画面スタブに遷移する
- [ ] 「青空文庫で見る」リンクが正しいURLを開く

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)