### PR TITLE
feat(author): 著者詳細画面の実装

### DIFF
--- a/Sources/Features/AuthorDetail/View/AuthorDetailScreen.swift
+++ b/Sources/Features/AuthorDetail/View/AuthorDetailScreen.swift
@@ -2,9 +2,108 @@ import SwiftUI
 
 struct AuthorDetailScreen: View {
     let person: Person
+    @State private var viewModel: AuthorDetailViewModel
+
+    init(person: Person) {
+        self.person = person
+        _viewModel = State(initialValue: AuthorDetailViewModel(person: person))
+    }
 
     var body: some View {
-        Text(person.fullName)
-            .navigationTitle("著者詳細")
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                portraitSection
+                profileSection
+                worksSection
+            }
+            .padding()
+        }
+        .navigationTitle("著者詳細")
+        .navigationBarTitleDisplayMode(.inline)
+        .task { await viewModel.load() }
+    }
+
+    @ViewBuilder
+    private var portraitSection: some View {
+        HStack(spacing: 16) {
+            if let url = viewModel.portraitURL {
+                AsyncImage(url: url) { image in
+                    image
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                } placeholder: {
+                    ProgressView()
+                }
+                .frame(width: 100, height: 130)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+            } else {
+                Image(systemName: "person.crop.rectangle")
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 100, height: 130)
+                    .foregroundStyle(.quaternary)
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text(person.fullName)
+                    .font(.title2)
+                    .fontWeight(.bold)
+
+                Text(person.fullNameYomi)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+
+                Text(person.lifespan)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+
+                if let source = viewModel.portraitSource {
+                    Text(source)
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var profileSection: some View {
+        if !person.lastNameRomaji.isEmpty {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("ローマ字表記")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text("\(person.lastNameRomaji) \(person.firstNameRomaji)")
+                    .font(.subheadline)
+            }
+            .padding()
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+        }
+    }
+
+    @ViewBuilder
+    private var worksSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("作品一覧（\(viewModel.works.count)件）")
+                .font(.headline)
+
+            if viewModel.isLoading {
+                ProgressView()
+            } else {
+                ForEach(viewModel.works) { book in
+                    NavigationLink {
+                        WorkDetailScreen(book: book)
+                    } label: {
+                        BookRowView(book: book)
+                    }
+                    .buttonStyle(.plain)
+
+                    if book.id != viewModel.works.last?.id {
+                        Divider()
+                    }
+                }
+            }
+        }
     }
 }

--- a/Sources/Features/AuthorDetail/ViewModel/AuthorDetailViewModel.swift
+++ b/Sources/Features/AuthorDetail/ViewModel/AuthorDetailViewModel.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+@Observable
+@MainActor
+final class AuthorDetailViewModel {
+    let person: Person
+    var works: [Book] = []
+    var portraitURL: URL?
+    var portraitSource: String?
+    var isLoading = false
+    var errorMessage: String?
+
+    private let catalogService = CatalogService.shared
+
+    init(person: Person) {
+        self.person = person
+    }
+
+    func load() async {
+        isLoading = true
+        async let worksTask: Void = loadWorks()
+        async let portraitTask: Void = loadPortrait()
+        _ = await (worksTask, portraitTask)
+        isLoading = false
+    }
+
+    private func loadWorks() async {
+        do {
+            works = try await catalogService.booksByPerson(personId: person.id)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func loadPortrait() async {
+        let fullName = "\(person.lastName)\(person.firstName)"
+        guard let encodedName = fullName.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+              let url = URL(
+                  string: "https://ja.wikipedia.org/api/rest_v1/page/summary/\(encodedName)"
+              )
+        else { return }
+
+        do {
+            let (data, response) = try await URLSession.shared.data(from: url)
+            guard let httpResponse = response as? HTTPURLResponse,
+                  httpResponse.statusCode == 200
+            else { return }
+
+            let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+            if let thumbnail = json?["thumbnail"] as? [String: Any],
+               let source = thumbnail["source"] as? String
+            {
+                portraitURL = URL(string: source)
+                portraitSource = "出典: Wikimedia Commons"
+            }
+        } catch {
+            // Portrait is optional; silently ignore errors
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- AuthorDetailScreen: 著者ポートレート、プロフィール、作品一覧を表示
- AuthorDetailViewModel: Wikipedia API から著者画像を非同期取得
- 「出典: Wikimedia Commons」のアトリビューション表示
- 画像取得失敗時にプレースホルダーアイコンを表示
- 作品一覧から WorkDetailScreen へ遷移可能

## Test plan
- [ ] 著者詳細画面に著者名・読み・生没年が表示される
- [ ] Wikipedia に画像がある著者（例: 夏目漱石）で画像が表示される
- [ ] 「出典: Wikimedia Commons」が画像下に表示される
- [ ] 画像のない著者でプレースホルダーが表示される
- [ ] 作品一覧が正しい件数表示される
- [ ] 作品タップで作品詳細に遷移する

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)