### PR TITLE
feat(reader): 読書画面の実装

### DIFF
--- a/Sources/App/Services/AozoraTextParser.swift
+++ b/Sources/App/Services/AozoraTextParser.swift
@@ -1,0 +1,84 @@
+import Foundation
+import SwiftUI
+
+struct AozoraTextParser: Sendable {
+    func parse(html: String) -> AttributedString {
+        let cleaned = extractBody(from: html)
+        let plainText = stripHTMLTags(cleaned)
+        let finalText = cleanAozoraNotations(plainText)
+
+        var result = AttributedString(finalText)
+        result.font = .body
+        return result
+    }
+
+    private func extractBody(from html: String) -> String {
+        if let mainStart = html.range(of: "<div class=\"main_text\">"),
+           let mainEnd = html.range(of: "<div class=\"bibliographical_information\">")
+        {
+            return String(html[mainStart.upperBound ..< mainEnd.lowerBound])
+        }
+
+        if let bodyStart = html.range(of: "<body"),
+           let bodyTagEnd = html[bodyStart.lowerBound...].range(of: ">"),
+           let bodyEnd = html.range(of: "</body>")
+        {
+            return String(html[bodyTagEnd.upperBound ..< bodyEnd.lowerBound])
+        }
+
+        return html
+    }
+
+    private func stripHTMLTags(_ text: String) -> String {
+        var result = text
+
+        result = result.replacingOccurrences(of: "<br[^>]*>", with: "\n", options: .regularExpression)
+        result = result.replacingOccurrences(of: "</p>", with: "\n\n", options: .caseInsensitive)
+        result = result.replacingOccurrences(of: "</div>", with: "\n", options: .caseInsensitive)
+
+        let rubyPattern = "<ruby><rb>([^<]*)</rb>[^<]*<rt>([^<]*)</rt>[^<]*</ruby>"
+        if let regex = try? NSRegularExpression(pattern: rubyPattern, options: []) {
+            let nsString = result as NSString
+            let matches = regex.matches(in: result, range: NSRange(location: 0, length: nsString.length))
+            for match in matches.reversed() {
+                let base = nsString.substring(with: match.range(at: 1))
+                let ruby = nsString.substring(with: match.range(at: 2))
+                result = (result as NSString).replacingCharacters(
+                    in: match.range,
+                    with: "\(base)（\(ruby)）"
+                )
+            }
+        }
+
+        result = result.replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression)
+
+        result = result.replacingOccurrences(of: "&nbsp;", with: " ")
+        result = result.replacingOccurrences(of: "&amp;", with: "&")
+        result = result.replacingOccurrences(of: "&lt;", with: "<")
+        result = result.replacingOccurrences(of: "&gt;", with: ">")
+        result = result.replacingOccurrences(of: "&quot;", with: "\"")
+        result = result.replacingOccurrences(of: "&#[0-9]+;", with: "", options: .regularExpression)
+
+        return result
+    }
+
+    private func cleanAozoraNotations(_ text: String) -> String {
+        var result = text
+        result = result.replacingOccurrences(
+            of: "※［＃[^］]*］",
+            with: "",
+            options: .regularExpression
+        )
+        result = result.replacingOccurrences(
+            of: "［＃[^］]*］",
+            with: "",
+            options: .regularExpression
+        )
+
+        while result.contains("\n\n\n") {
+            result = result.replacingOccurrences(of: "\n\n\n", with: "\n\n")
+        }
+
+        return result.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/Sources/Features/Reader/View/ReaderScreen.swift
+++ b/Sources/Features/Reader/View/ReaderScreen.swift
@@ -2,9 +2,37 @@ import SwiftUI
 
 struct ReaderScreen: View {
     let book: Book
+    @State private var viewModel: ReaderViewModel
+
+    init(book: Book) {
+        self.book = book
+        _viewModel = State(initialValue: ReaderViewModel(book: book))
+    }
 
     var body: some View {
-        Text("読書画面（実装予定）")
-            .navigationTitle(book.title)
+        Group {
+            if viewModel.isLoading {
+                VStack(spacing: 16) {
+                    ProgressView()
+                    Text("本文を取得中…")
+                        .foregroundStyle(.secondary)
+                }
+            } else if let error = viewModel.errorMessage {
+                ContentUnavailableView(
+                    "読み込みエラー",
+                    systemImage: "exclamationmark.triangle",
+                    description: Text(error)
+                )
+            } else if let content = viewModel.content {
+                ScrollView {
+                    Text(content)
+                        .textSelection(.enabled)
+                        .padding()
+                }
+            }
+        }
+        .navigationTitle(book.title)
+        .navigationBarTitleDisplayMode(.inline)
+        .task { await viewModel.loadContent() }
     }
 }

--- a/Sources/Features/Reader/ViewModel/ReaderViewModel.swift
+++ b/Sources/Features/Reader/ViewModel/ReaderViewModel.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+@Observable
+@MainActor
+final class ReaderViewModel {
+    let book: Book
+    var content: AttributedString?
+    var isLoading = false
+    var errorMessage: String?
+
+    private let textFetchService = TextFetchService.shared
+    private let parser = AozoraTextParser()
+
+    init(book: Book) {
+        self.book = book
+    }
+
+    func loadContent() async {
+        isLoading = true
+        errorMessage = nil
+
+        do {
+            let html = try await textFetchService.fetchText(for: book)
+            content = parser.parse(html: html)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+
+        isLoading = false
+    }
+}


### PR DESCRIPTION
## Summary
- ReaderScreen: 作品本文をスクロールで読める画面
- ReaderViewModel: TextFetchService 経由で非同期テキスト取得
- AozoraTextParser: 青空文庫 HTML → AttributedString 変換
  - ルビ（ruby タグ）をカッコ表記に変換
  - HTML タグ除去、実体参照デコード
  - 青空文庫注記（※[＃...]）除去
- テキスト選択可能

## Test plan
- [ ] 作品詳細の「読む」ボタンで読書画面が開く
- [ ] 本文がスクロール表示される
- [ ] ルビが「漢字（かんじ）」形式で表示される
- [ ] 読み込み中にプログレスが表示される
- [ ] テキスト選択が動作する
- [ ] 取得エラー時にエラーメッセージが表示される

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)