### PR TITLE
feat(settings): 読書設定の実装

### DIFF
--- a/Sources/App/Models/ReadingSettings.swift
+++ b/Sources/App/Models/ReadingSettings.swift
@@ -1,0 +1,129 @@
+import Foundation
+import SwiftUI
+
+enum FontSizeLevel: Int, CaseIterable, Sendable, Codable {
+    case small = 14
+    case medium = 17
+    case large = 21
+    case extraLarge = 26
+
+    var label: String {
+        switch self {
+        case .small: "小"
+        case .medium: "中"
+        case .large: "大"
+        case .extraLarge: "特大"
+        }
+    }
+
+    var font: Font {
+        .system(size: CGFloat(rawValue))
+    }
+}
+
+enum LineSpacingLevel: Int, CaseIterable, Sendable, Codable {
+    case narrow = 4
+    case normal = 8
+    case wide = 14
+
+    var label: String {
+        switch self {
+        case .narrow: "狭い"
+        case .normal: "普通"
+        case .wide: "広い"
+        }
+    }
+
+    var value: CGFloat {
+        CGFloat(rawValue)
+    }
+}
+
+enum PaddingLevel: Int, CaseIterable, Sendable, Codable {
+    case narrow = 8
+    case normal = 16
+    case wide = 32
+
+    var label: String {
+        switch self {
+        case .narrow: "狭い"
+        case .normal: "普通"
+        case .wide: "広い"
+        }
+    }
+
+    var value: CGFloat {
+        CGFloat(rawValue)
+    }
+}
+
+enum ReadingTheme: String, CaseIterable, Sendable, Codable {
+    case light
+    case dark
+    case sepia
+
+    var label: String {
+        switch self {
+        case .light: "ライト"
+        case .dark: "ダーク"
+        case .sepia: "セピア"
+        }
+    }
+
+    var backgroundColor: Color {
+        switch self {
+        case .light: .white
+        case .dark: Color(red: 0.1, green: 0.1, blue: 0.1)
+        case .sepia: Color(red: 0.96, green: 0.93, blue: 0.86)
+        }
+    }
+
+    var textColor: Color {
+        switch self {
+        case .light: .black
+        case .dark: .white
+        case .sepia: Color(red: 0.3, green: 0.2, blue: 0.1)
+        }
+    }
+}
+
+@Observable
+final class ReadingSettings: @unchecked Sendable {
+    static let shared = ReadingSettings()
+
+    var fontSize: FontSizeLevel {
+        didSet { save() }
+    }
+
+    var lineSpacing: LineSpacingLevel {
+        didSet { save() }
+    }
+
+    var padding: PaddingLevel {
+        didSet { save() }
+    }
+
+    var theme: ReadingTheme {
+        didSet { save() }
+    }
+
+    private let defaults = UserDefaults.standard
+    private let fontSizeKey = "readingFontSize"
+    private let lineSpacingKey = "readingLineSpacing"
+    private let paddingKey = "readingPadding"
+    private let themeKey = "readingTheme"
+
+    private init() {
+        fontSize = FontSizeLevel(rawValue: defaults.integer(forKey: fontSizeKey)) ?? .medium
+        lineSpacing = LineSpacingLevel(rawValue: defaults.integer(forKey: lineSpacingKey)) ?? .normal
+        padding = PaddingLevel(rawValue: defaults.integer(forKey: paddingKey)) ?? .normal
+        theme = ReadingTheme(rawValue: defaults.string(forKey: themeKey) ?? "") ?? .light
+    }
+
+    private func save() {
+        defaults.set(fontSize.rawValue, forKey: fontSizeKey)
+        defaults.set(lineSpacing.rawValue, forKey: lineSpacingKey)
+        defaults.set(padding.rawValue, forKey: paddingKey)
+        defaults.set(theme.rawValue, forKey: themeKey)
+    }
+}

--- a/Sources/Features/Reader/View/ReaderScreen.swift
+++ b/Sources/Features/Reader/View/ReaderScreen.swift
@@ -3,6 +3,8 @@ import SwiftUI
 struct ReaderScreen: View {
     let book: Book
     @State private var viewModel: ReaderViewModel
+    @State private var settings = ReadingSettings.shared
+    @State private var showSettings = false
 
     init(book: Book) {
         self.book = book
@@ -26,13 +28,29 @@ struct ReaderScreen: View {
             } else if let content = viewModel.content {
                 ScrollView {
                     Text(content)
+                        .font(settings.fontSize.font)
+                        .lineSpacing(settings.lineSpacing.value)
+                        .foregroundStyle(settings.theme.textColor)
                         .textSelection(.enabled)
-                        .padding()
+                        .padding(settings.padding.value)
                 }
+                .background(settings.theme.backgroundColor)
             }
         }
         .navigationTitle(book.title)
         .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    showSettings = true
+                } label: {
+                    Image(systemName: "textformat.size")
+                }
+            }
+        }
+        .sheet(isPresented: $showSettings) {
+            ReadingSettingsSheet(settings: settings)
+        }
         .task { await viewModel.loadContent() }
     }
 }

--- a/Sources/Features/Reader/View/ReadingSettingsSheet.swift
+++ b/Sources/Features/Reader/View/ReadingSettingsSheet.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+struct ReadingSettingsSheet: View {
+    @Bindable var settings: ReadingSettings
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("フォントサイズ") {
+                    Picker("サイズ", selection: $settings.fontSize) {
+                        ForEach(FontSizeLevel.allCases, id: \.self) { level in
+                            Text(level.label).tag(level)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                }
+
+                Section("行間") {
+                    Picker("行間", selection: $settings.lineSpacing) {
+                        ForEach(LineSpacingLevel.allCases, id: \.self) { level in
+                            Text(level.label).tag(level)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                }
+
+                Section("余白") {
+                    Picker("余白", selection: $settings.padding) {
+                        ForEach(PaddingLevel.allCases, id: \.self) { level in
+                            Text(level.label).tag(level)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                }
+
+                Section("テーマ") {
+                    Picker("テーマ", selection: $settings.theme) {
+                        ForEach(ReadingTheme.allCases, id: \.self) { theme in
+                            Text(theme.label).tag(theme)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                }
+
+                Section("プレビュー") {
+                    Text("吾輩は猫である。名前はまだ無い。")
+                        .font(settings.fontSize.font)
+                        .lineSpacing(settings.lineSpacing.value)
+                        .foregroundStyle(settings.theme.textColor)
+                        .padding(settings.padding.value)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(settings.theme.backgroundColor)
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
+                }
+            }
+            .navigationTitle("読書設定")
+            .navigationBarTitleDisplayMode(.inline)
+        }
+        .presentationDetents([.medium])
+    }
+}


### PR DESCRIPTION
## Summary
- ReadingSettings: UserDefaults で永続化される読書設定モデル
- フォントサイズ（小/中/大/特大）、行間（狭い/普通/広い）、余白（狭い/普通/広い）
- テーマ切替（ライト/ダーク/セピア）
- ReadingSettingsSheet: セグメントピッカー + プレビュー付き設定画面
- ReaderScreen に設定を適用

## Test plan
- [ ] 読書画面のツールバーから設定シートが開く
- [ ] フォントサイズ変更がリアルタイムで反映される
- [ ] 行間・余白変更が反映される
- [ ] テーマ切替でテキスト色・背景色が変わる
- [ ] プレビューに設定が反映される
- [ ] アプリ再起動後も設定が保持される

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)