### PR TITLE
feat(favorites): お気に入り機能の実装

### DIFF
--- a/Sources/App/ContentView.swift
+++ b/Sources/App/ContentView.swift
@@ -11,8 +11,7 @@ struct ContentView: View {
             }
 
             NavigationStack {
-                Text("お気に入り画面（実装予定）")
-                    .navigationTitle("お気に入り")
+                FavoritesScreen()
             }
             .tabItem {
                 Label("お気に入り", systemImage: "heart.fill")

--- a/Sources/Features/Favorites/View/FavoritesScreen.swift
+++ b/Sources/Features/Favorites/View/FavoritesScreen.swift
@@ -1,0 +1,63 @@
+import SwiftData
+import SwiftUI
+
+struct FavoritesScreen: View {
+    @Query(sort: \FavoriteBook.addedAt, order: .reverse) private var favorites: [FavoriteBook]
+    @Environment(\.modelContext) private var modelContext
+
+    var body: some View {
+        Group {
+            if favorites.isEmpty {
+                ContentUnavailableView(
+                    "お気に入りなし",
+                    systemImage: "heart.slash",
+                    description: Text("作品詳細画面からお気に入りに追加できます")
+                )
+            } else {
+                List {
+                    ForEach(favorites) { favorite in
+                        NavigationLink {
+                            FavoriteBookDestination(favorite: favorite)
+                        } label: {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(favorite.title)
+                                    .font(.headline)
+                                    .lineLimit(2)
+                                Text(favorite.authorName)
+                                    .font(.subheadline)
+                                    .foregroundStyle(.secondary)
+                            }
+                            .padding(.vertical, 4)
+                        }
+                    }
+                    .onDelete { indexSet in
+                        for index in indexSet {
+                            modelContext.delete(favorites[index])
+                        }
+                        try? modelContext.save()
+                    }
+                }
+                .listStyle(.plain)
+            }
+        }
+        .navigationTitle("お気に入り")
+    }
+}
+
+private struct FavoriteBookDestination: View {
+    let favorite: FavoriteBook
+    @State private var book: Book?
+
+    var body: some View {
+        Group {
+            if let book {
+                WorkDetailScreen(book: book)
+            } else {
+                ProgressView()
+            }
+        }
+        .task {
+            book = try? await CatalogService.shared.book(id: favorite.bookId)
+        }
+    }
+}

--- a/Sources/Features/Favorites/ViewModel/FavoritesViewModel.swift
+++ b/Sources/Features/Favorites/ViewModel/FavoritesViewModel.swift
@@ -1,0 +1,34 @@
+import Foundation
+import SwiftData
+
+@Observable
+@MainActor
+final class FavoritesViewModel {
+    func isFavorite(bookId: Int, context: ModelContext) -> Bool {
+        let descriptor = FetchDescriptor<FavoriteBook>(
+            predicate: #Predicate { $0.bookId == bookId }
+        )
+        return (try? context.fetchCount(descriptor)) ?? 0 > 0
+    }
+
+    func toggleFavorite(book: Book, context: ModelContext) {
+        let bookId = book.id
+        let descriptor = FetchDescriptor<FavoriteBook>(
+            predicate: #Predicate { $0.bookId == bookId }
+        )
+
+        if let existing = try? context.fetch(descriptor).first {
+            context.delete(existing)
+        } else {
+            let favorite = FavoriteBook(
+                bookId: book.id,
+                title: book.title,
+                authorName: book.authorName,
+                personId: book.personId
+            )
+            context.insert(favorite)
+        }
+
+        try? context.save()
+    }
+}

--- a/Sources/Features/WorkDetail/View/WorkDetailScreen.swift
+++ b/Sources/Features/WorkDetail/View/WorkDetailScreen.swift
@@ -1,8 +1,12 @@
+import SwiftData
 import SwiftUI
 
 struct WorkDetailScreen: View {
     let book: Book
     @State private var viewModel: WorkDetailViewModel
+    @State private var favoritesVM = FavoritesViewModel()
+    @State private var isFavorite = false
+    @Environment(\.modelContext) private var modelContext
 
     init(book: Book) {
         self.book = book
@@ -20,7 +24,21 @@ struct WorkDetailScreen: View {
         }
         .navigationTitle("作品詳細")
         .navigationBarTitleDisplayMode(.inline)
-        .task { await viewModel.loadAuthor() }
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    favoritesVM.toggleFavorite(book: book, context: modelContext)
+                    isFavorite.toggle()
+                } label: {
+                    Image(systemName: isFavorite ? "heart.fill" : "heart")
+                        .foregroundStyle(isFavorite ? .red : .secondary)
+                }
+            }
+        }
+        .task {
+            await viewModel.loadAuthor()
+            isFavorite = favoritesVM.isFavorite(bookId: book.id, context: modelContext)
+        }
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
- FavoritesScreen: SwiftData `@Query` でお気に入り一覧表示
- FavoritesViewModel: お気に入り追加/削除/判定
- WorkDetailScreen: ツールバーにハートボタン追加
- スワイプ削除対応
- お気に入りから作品詳細への遷移

## Test plan
- [ ] 作品詳細のハートボタンでお気に入り追加/解除ができる
- [ ] お気に入りタブに登録済み作品が新しい順で表示される
- [ ] お気に入り一覧から作品詳細に遷移できる
- [ ] スワイプで削除できる
- [ ] アプリ再起動後もお気に入りが保持される
- [ ] お気に入りが0件の時に空状態メッセージが表示される

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)