### PR TITLE
feat(offline): オフライン読書機能の実装

### DIFF
--- a/Sources/App/Services/TextFetchService.swift
+++ b/Sources/App/Services/TextFetchService.swift
@@ -4,17 +4,27 @@ actor TextFetchService {
     static let shared = TextFetchService()
 
     private let session: URLSession
-    private var cache: [Int: String] = [:]
+    private var memoryCache: [Int: String] = [:]
+    private let cacheDirectory: URL
 
     private init() {
         let config = URLSessionConfiguration.default
         config.timeoutIntervalForRequest = 30
         session = URLSession(configuration: config)
+
+        let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+        cacheDirectory = caches.appendingPathComponent("AozoraTexts", isDirectory: true)
+        try? FileManager.default.createDirectory(at: cacheDirectory, withIntermediateDirectories: true)
     }
 
     func fetchText(for book: Book) async throws -> String {
-        if let cached = cache[book.id] {
+        if let cached = memoryCache[book.id] {
             return cached
+        }
+
+        if let diskCached = loadFromDisk(bookId: book.id) {
+            memoryCache[book.id] = diskCached
+            return diskCached
         }
 
         guard let url = book.htmlFileURL ?? book.textFileURL else {
@@ -34,16 +44,51 @@ actor TextFetchService {
             throw TextFetchError.decodingFailed
         }
 
-        cache[book.id] = text
+        memoryCache[book.id] = text
+        saveToDisk(bookId: book.id, text: text)
         return text
     }
 
-    func clearCache(for bookId: Int) {
-        cache.removeValue(forKey: bookId)
+    func isCached(bookId: Int) -> Bool {
+        memoryCache[bookId] != nil || FileManager.default.fileExists(atPath: cacheFile(for: bookId).path)
+    }
+
+    func deleteCachedText(bookId: Int) {
+        memoryCache.removeValue(forKey: bookId)
+        let file = cacheFile(for: bookId)
+        try? FileManager.default.removeItem(at: file)
     }
 
     func clearAllCache() {
-        cache.removeAll()
+        memoryCache.removeAll()
+        try? FileManager.default.removeItem(at: cacheDirectory)
+        try? FileManager.default.createDirectory(at: cacheDirectory, withIntermediateDirectories: true)
+    }
+
+    func cachedBookIds() -> Set<Int> {
+        var ids = Set(memoryCache.keys)
+        if let files = try? FileManager.default.contentsOfDirectory(atPath: cacheDirectory.path) {
+            for file in files where file.hasSuffix(".txt") {
+                if let id = Int(file.replacingOccurrences(of: ".txt", with: "")) {
+                    ids.insert(id)
+                }
+            }
+        }
+        return ids
+    }
+
+    private func cacheFile(for bookId: Int) -> URL {
+        cacheDirectory.appendingPathComponent("\(bookId).txt")
+    }
+
+    private func saveToDisk(bookId: Int, text: String) {
+        let file = cacheFile(for: bookId)
+        try? text.write(to: file, atomically: true, encoding: .utf8)
+    }
+
+    private func loadFromDisk(bookId: Int) -> String? {
+        let file = cacheFile(for: bookId)
+        return try? String(contentsOf: file, encoding: .utf8)
     }
 
     private func detectEncoding(from data: Data, response: HTTPURLResponse) -> String.Encoding {
@@ -70,6 +115,7 @@ enum TextFetchError: LocalizedError {
     case noTextURL
     case fetchFailed
     case decodingFailed
+    case offline
 
     var errorDescription: String? {
         switch self {
@@ -79,6 +125,8 @@ enum TextFetchError: LocalizedError {
             "テキストの取得に失敗しました"
         case .decodingFailed:
             "テキストのデコードに失敗しました"
+        case .offline:
+            "オフラインです。この作品はまだダウンロードされていません"
         }
     }
 }

--- a/Sources/Features/Search/View/BookRowView.swift
+++ b/Sources/Features/Search/View/BookRowView.swift
@@ -2,22 +2,33 @@ import SwiftUI
 
 struct BookRowView: View {
     let book: Book
+    var showCacheIcon = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text(book.title)
-                .font(.headline)
-                .lineLimit(2)
+        HStack {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(book.title)
+                    .font(.headline)
+                    .lineLimit(2)
 
-            Text(book.authorName)
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
+                Text(book.authorName)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
 
-            if !book.subtitle.isEmpty {
-                Text(book.subtitle)
+                if !book.subtitle.isEmpty {
+                    Text(book.subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                        .lineLimit(1)
+                }
+            }
+
+            Spacer()
+
+            if showCacheIcon {
+                Image(systemName: "arrow.down.circle.fill")
+                    .foregroundStyle(.green)
                     .font(.caption)
-                    .foregroundStyle(.tertiary)
-                    .lineLimit(1)
             }
         }
         .padding(.vertical, 4)


### PR DESCRIPTION
## Summary
- TextFetchService にファイルシステムキャッシュを追加
- 一度読んだ作品はディスクに保存され、オフラインでも読める
- メモリキャッシュ → ディスクキャッシュ → ネットワーク の3段構え
- BookRowView にキャッシュ済みアイコン表示対応
- キャッシュ削除・一括クリア API を提供

## Test plan
- [ ] 作品を読んだ後、機内モードでも同じ作品が読める
- [ ] キャッシュ済み作品にアイコンが表示される（showCacheIcon=true時）
- [ ] 未キャッシュ作品をオフラインで開くとエラーが出る
- [ ] アプリ再起動後もキャッシュが維持される

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)