### PR TITLE
feat(cover): AI表紙生成プレースホルダーの実装

### DIFF
--- a/Sources/App/Services/CoverImageService.swift
+++ b/Sources/App/Services/CoverImageService.swift
@@ -1,0 +1,23 @@
+import Foundation
+import SwiftUI
+
+actor CoverImageService {
+    static let shared = CoverImageService()
+
+    private init() {}
+
+    func coverColor(for book: Book) -> Color {
+        let hash = abs(book.title.hashValue)
+        let colors: [Color] = [
+            Color(red: 0.2, green: 0.4, blue: 0.6),
+            Color(red: 0.6, green: 0.3, blue: 0.3),
+            Color(red: 0.3, green: 0.5, blue: 0.3),
+            Color(red: 0.5, green: 0.4, blue: 0.6),
+            Color(red: 0.6, green: 0.5, blue: 0.3),
+            Color(red: 0.4, green: 0.5, blue: 0.5),
+            Color(red: 0.5, green: 0.3, blue: 0.5),
+            Color(red: 0.3, green: 0.4, blue: 0.5),
+        ]
+        return colors[hash % colors.count]
+    }
+}

--- a/Sources/Features/Search/View/BookCoverView.swift
+++ b/Sources/Features/Search/View/BookCoverView.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+struct BookCoverView: View {
+    let book: Book
+    var width: CGFloat = 60
+    var height: CGFloat = 85
+
+    private var coverColor: Color {
+        let hash = abs(book.title.hashValue)
+        let colors: [Color] = [
+            Color(red: 0.2, green: 0.4, blue: 0.6),
+            Color(red: 0.6, green: 0.3, blue: 0.3),
+            Color(red: 0.3, green: 0.5, blue: 0.3),
+            Color(red: 0.5, green: 0.4, blue: 0.6),
+            Color(red: 0.6, green: 0.5, blue: 0.3),
+            Color(red: 0.4, green: 0.5, blue: 0.5),
+            Color(red: 0.5, green: 0.3, blue: 0.5),
+            Color(red: 0.3, green: 0.4, blue: 0.5),
+        ]
+        return colors[hash % colors.count]
+    }
+
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 6)
+                .fill(coverColor.gradient)
+
+            VStack(spacing: 2) {
+                Text(String(book.title.prefix(4)))
+                    .font(.system(size: 11, weight: .bold))
+                    .foregroundStyle(.white)
+                    .lineLimit(2)
+                    .multilineTextAlignment(.center)
+
+                Text("参考ビジュアル")
+                    .font(.system(size: 5))
+                    .foregroundStyle(.white.opacity(0.6))
+            }
+            .padding(4)
+        }
+        .frame(width: width, height: height)
+    }
+}

--- a/Sources/Features/Search/View/BookRowView.swift
+++ b/Sources/Features/Search/View/BookRowView.swift
@@ -5,7 +5,9 @@ struct BookRowView: View {
     var showCacheIcon = false
 
     var body: some View {
-        HStack {
+        HStack(spacing: 12) {
+            BookCoverView(book: book)
+
             VStack(alignment: .leading, spacing: 4) {
                 Text(book.title)
                     .font(.headline)

--- a/Sources/Features/WorkDetail/View/WorkDetailScreen.swift
+++ b/Sources/Features/WorkDetail/View/WorkDetailScreen.swift
@@ -44,27 +44,33 @@ struct WorkDetailScreen: View {
     @ViewBuilder
     private var headerSection: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text(book.title)
-                .font(.title)
-                .fontWeight(.bold)
+            HStack(alignment: .top, spacing: 16) {
+                BookCoverView(book: book, width: 100, height: 140)
 
-            if !book.subtitle.isEmpty {
-                Text(book.subtitle)
-                    .font(.title3)
-                    .foregroundStyle(.secondary)
-            }
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(book.title)
+                        .font(.title2)
+                        .fontWeight(.bold)
 
-            if let author = viewModel.author {
-                NavigationLink {
-                    AuthorDetailScreen(person: author)
-                } label: {
-                    Label(author.fullName, systemImage: "person")
-                        .font(.headline)
+                    if !book.subtitle.isEmpty {
+                        Text(book.subtitle)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    if let author = viewModel.author {
+                        NavigationLink {
+                            AuthorDetailScreen(person: author)
+                        } label: {
+                            Label(author.fullName, systemImage: "person")
+                                .font(.subheadline)
+                        }
+                    } else {
+                        Label(book.authorName, systemImage: "person")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
                 }
-            } else {
-                Label(book.authorName, systemImage: "person")
-                    .font(.headline)
-                    .foregroundStyle(.secondary)
             }
         }
     }


### PR DESCRIPTION
## Summary
- BookCoverView: タイトルハッシュベースのグラデーション表紙
- 「参考ビジュアル」ラベルで出典誤認を防止
- 検索結果リスト・作品詳細画面に表紙画像を表示
- CoverImageService: 将来の AI 画像生成 API 連携用インターフェース
- MVP ではプレースホルダー表示、API キー設定後に実画像生成対応予定

## Test plan
- [ ] 検索結果に表紙サムネイルが表示される
- [ ] 作品詳細に大きな表紙が表示される
- [ ] 「参考ビジュアル」ラベルが見える
- [ ] 異なる作品で異なる色が表示される

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)