### PR TITLE
feat(review): レビュー機能（ローカル保存）の実装

### DIFF
--- a/Sources/Features/Review/View/ReviewSheet.swift
+++ b/Sources/Features/Review/View/ReviewSheet.swift
@@ -1,0 +1,66 @@
+import SwiftData
+import SwiftUI
+
+struct ReviewSheet: View {
+    let book: Book
+    @State private var viewModel = ReviewViewModel()
+    @Environment(\.modelContext) private var modelContext
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("評価") {
+                    HStack(spacing: 8) {
+                        ForEach(1 ... 5, id: \.self) { star in
+                            Button {
+                                viewModel.rating = star
+                            } label: {
+                                Image(systemName: star <= viewModel.rating ? "star.fill" : "star")
+                                    .font(.title2)
+                                    .foregroundStyle(star <= viewModel.rating ? .yellow : .gray)
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.vertical, 8)
+                }
+
+                Section("感想") {
+                    TextEditor(text: $viewModel.comment)
+                        .frame(minHeight: 120)
+                }
+
+                Section {
+                    Button("保存") {
+                        viewModel.saveReview(book: book, context: modelContext)
+                        dismiss()
+                    }
+                    .disabled(viewModel.rating == 0)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                }
+
+                if viewModel.existingReview != nil {
+                    Section {
+                        Button("レビューを削除", role: .destructive) {
+                            viewModel.deleteReview(context: modelContext)
+                            dismiss()
+                        }
+                        .frame(maxWidth: .infinity, alignment: .center)
+                    }
+                }
+            }
+            .navigationTitle("レビュー")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("キャンセル") { dismiss() }
+                }
+            }
+            .task {
+                viewModel.loadReview(bookId: book.id, context: modelContext)
+            }
+        }
+    }
+}

--- a/Sources/Features/Review/View/StarRatingView.swift
+++ b/Sources/Features/Review/View/StarRatingView.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+struct StarRatingView: View {
+    let rating: Int
+    var size: Font = .caption
+
+    var body: some View {
+        HStack(spacing: 2) {
+            ForEach(1 ... 5, id: \.self) { star in
+                Image(systemName: star <= rating ? "star.fill" : "star")
+                    .font(size)
+                    .foregroundStyle(star <= rating ? .yellow : .gray.opacity(0.3))
+            }
+        }
+    }
+}

--- a/Sources/Features/Review/ViewModel/ReviewViewModel.swift
+++ b/Sources/Features/Review/ViewModel/ReviewViewModel.swift
@@ -1,0 +1,50 @@
+import Foundation
+import SwiftData
+
+@Observable
+@MainActor
+final class ReviewViewModel {
+    var rating: Int = 0
+    var comment: String = ""
+    var existingReview: BookReview?
+
+    func loadReview(bookId: Int, context: ModelContext) {
+        let descriptor = FetchDescriptor<BookReview>(
+            predicate: #Predicate { $0.bookId == bookId }
+        )
+        if let review = try? context.fetch(descriptor).first {
+            existingReview = review
+            rating = review.rating
+            comment = review.comment
+        }
+    }
+
+    func saveReview(book: Book, context: ModelContext) {
+        if let existing = existingReview {
+            existing.rating = rating
+            existing.comment = comment
+            existing.updatedAt = .now
+        } else {
+            let review = BookReview(
+                bookId: book.id,
+                title: book.title,
+                authorName: book.authorName,
+                rating: rating,
+                comment: comment
+            )
+            context.insert(review)
+            existingReview = review
+        }
+        try? context.save()
+    }
+
+    func deleteReview(context: ModelContext) {
+        if let existing = existingReview {
+            context.delete(existing)
+            try? context.save()
+            existingReview = nil
+            rating = 0
+            comment = ""
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- ReviewSheet: 星評価（1-5）+ テキスト感想入力フォーム
- ReviewViewModel: SwiftData での CRUD 操作
- StarRatingView: 再利用可能な星評価コンポーネント
- WorkDetailScreen にレビューセクションを統合
- レビューの作成・編集・削除に対応

## Test plan
- [ ] 作品詳細の「レビューを書く」で入力シートが開く
- [ ] 星をタップして1-5の評価が設定できる
- [ ] テキスト感想を入力・保存できる
- [ ] 保存後に作品詳細にレビューが表示される
- [ ] 「編集」ボタンで既存レビューを編集できる
- [ ] 「レビューを削除」でレビューが消える
- [ ] 評価0（未設定）では保存ボタンが無効

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)