### PR TITLE
feat(reader): 縦書きページめくりモードを追加

### DIFF
--- a/Sources/App/Models/ReadingSettings.swift
+++ b/Sources/App/Models/ReadingSettings.swift
@@ -87,9 +87,25 @@ enum ReadingTheme: String, CaseIterable, Sendable, Codable {
     }
 }
 
+enum ReadingLayoutMode: String, CaseIterable, Sendable, Codable {
+    case horizontalScroll
+    case verticalPaged
+
+    var label: String {
+        switch self {
+        case .horizontalScroll: "横書きスクロール"
+        case .verticalPaged: "縦書きページ"
+        }
+    }
+}
+
 @Observable
 final class ReadingSettings: @unchecked Sendable {
     static let shared = ReadingSettings()
+
+    var layoutMode: ReadingLayoutMode {
+        didSet { save() }
+    }
 
     var fontSize: FontSizeLevel {
         didSet { save() }
@@ -108,12 +124,14 @@ final class ReadingSettings: @unchecked Sendable {
     }
 
     private let defaults = UserDefaults.standard
+    private let layoutModeKey = "readingLayoutMode"
     private let fontSizeKey = "readingFontSize"
     private let lineSpacingKey = "readingLineSpacing"
     private let paddingKey = "readingPadding"
     private let themeKey = "readingTheme"
 
     private init() {
+        layoutMode = ReadingLayoutMode(rawValue: defaults.string(forKey: layoutModeKey) ?? "") ?? .horizontalScroll
         fontSize = FontSizeLevel(rawValue: defaults.integer(forKey: fontSizeKey)) ?? .medium
         lineSpacing = LineSpacingLevel(rawValue: defaults.integer(forKey: lineSpacingKey)) ?? .normal
         padding = PaddingLevel(rawValue: defaults.integer(forKey: paddingKey)) ?? .normal
@@ -121,6 +139,7 @@ final class ReadingSettings: @unchecked Sendable {
     }
 
     private func save() {
+        defaults.set(layoutMode.rawValue, forKey: layoutModeKey)
         defaults.set(fontSize.rawValue, forKey: fontSizeKey)
         defaults.set(lineSpacing.rawValue, forKey: lineSpacingKey)
         defaults.set(padding.rawValue, forKey: paddingKey)

--- a/Sources/Features/Reader/View/ReaderScreen.swift
+++ b/Sources/Features/Reader/View/ReaderScreen.swift
@@ -28,35 +28,42 @@ struct ReaderScreen: View {
                     description: Text(error)
                 )
             } else if let content = viewModel.content {
-                ScrollViewReader { _ in
-                    ScrollView {
-                        VStack(spacing: 0) {
-                            Color.clear
-                                .frame(height: 0)
-                                .id("top")
-
-                            Text(content)
-                                .font(settings.fontSize.font)
-                                .lineSpacing(settings.lineSpacing.value)
-                                .foregroundStyle(settings.theme.textColor)
-                                .textSelection(.enabled)
-                                .padding(settings.padding.value)
-                        }
-                        .background(
-                            GeometryReader { geo in
-                                Color.clear.preference(
-                                    key: ScrollOffsetKey.self,
-                                    value: -geo.frame(in: .named("scroll")).origin.y
-                                )
-                            }
-                        )
-                    }
-                    .coordinateSpace(name: "scroll")
-                    .onPreferenceChange(ScrollOffsetKey.self) { offset in
+                if settings.layoutMode == .verticalPaged {
+                    VerticalPagedReaderView(content: content, settings: settings) { offset in
                         viewModel.saveBookmark(scrollOffset: offset, context: modelContext)
                     }
+                    .background(settings.theme.backgroundColor)
+                } else {
+                    ScrollViewReader { _ in
+                        ScrollView {
+                            VStack(spacing: 0) {
+                                Color.clear
+                                    .frame(height: 0)
+                                    .id("top")
+
+                                Text(content)
+                                    .font(settings.fontSize.font)
+                                    .lineSpacing(settings.lineSpacing.value)
+                                    .foregroundStyle(settings.theme.textColor)
+                                    .textSelection(.enabled)
+                                    .padding(settings.padding.value)
+                            }
+                            .background(
+                                GeometryReader { geo in
+                                    Color.clear.preference(
+                                        key: ScrollOffsetKey.self,
+                                        value: -geo.frame(in: .named("scroll")).origin.y
+                                    )
+                                }
+                            )
+                        }
+                        .coordinateSpace(name: "scroll")
+                        .onPreferenceChange(ScrollOffsetKey.self) { offset in
+                            viewModel.saveBookmark(scrollOffset: offset, context: modelContext)
+                        }
+                    }
+                    .background(settings.theme.backgroundColor)
                 }
-                .background(settings.theme.backgroundColor)
             } else {
                 ContentUnavailableView(
                     "本文が表示できません",

--- a/Sources/Features/Reader/View/ReadingSettingsSheet.swift
+++ b/Sources/Features/Reader/View/ReadingSettingsSheet.swift
@@ -6,6 +6,15 @@ struct ReadingSettingsSheet: View {
     var body: some View {
         NavigationStack {
             Form {
+                Section("表示モード") {
+                    Picker("表示", selection: $settings.layoutMode) {
+                        ForEach(ReadingLayoutMode.allCases, id: \.self) { mode in
+                            Text(mode.label).tag(mode)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                }
+
                 Section("フォントサイズ") {
                     Picker("サイズ", selection: $settings.fontSize) {
                         ForEach(FontSizeLevel.allCases, id: \.self) { level in

--- a/Sources/Features/Reader/View/VerticalPagedReaderView.swift
+++ b/Sources/Features/Reader/View/VerticalPagedReaderView.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+import UIKit
+
+struct VerticalPagedReaderView: UIViewRepresentable {
+    let content: AttributedString
+    let settings: ReadingSettings
+    let onScroll: (Double) -> Void
+
+    func makeUIView(context: Context) -> UITextView {
+        let textView = UITextView()
+        textView.isEditable = false
+        textView.isSelectable = true
+        textView.backgroundColor = .clear
+        textView.delegate = context.coordinator
+        textView.isPagingEnabled = true
+        textView.alwaysBounceHorizontal = true
+        textView.alwaysBounceVertical = false
+        textView.showsHorizontalScrollIndicator = false
+        textView.showsVerticalScrollIndicator = false
+        textView.textContainerInset = UIEdgeInsets(
+            top: settings.padding.value,
+            left: settings.padding.value,
+            bottom: settings.padding.value,
+            right: settings.padding.value
+        )
+        textView.textContainer.lineFragmentPadding = 0
+        textView.semanticContentAttribute = .forceRightToLeft
+        return textView
+    }
+
+    func updateUIView(_ uiView: UITextView, context: Context) {
+        uiView.backgroundColor = UIColor(settings.theme.backgroundColor)
+
+        let mutable = NSMutableAttributedString(attributedString: NSAttributedString(content))
+        let fullRange = NSRange(location: 0, length: mutable.length)
+        mutable.addAttributes([
+            .verticalGlyphForm: 1,
+            .foregroundColor: UIColor(settings.theme.textColor),
+            .font: UIFont.systemFont(ofSize: CGFloat(settings.fontSize.rawValue))
+        ], range: fullRange)
+
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.lineSpacing = settings.lineSpacing.value
+        paragraph.alignment = .natural
+        mutable.addAttribute(.paragraphStyle, value: paragraph, range: fullRange)
+
+        uiView.attributedText = mutable
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onScroll: onScroll)
+    }
+
+    final class Coordinator: NSObject, UITextViewDelegate {
+        let onScroll: (Double) -> Void
+
+        init(onScroll: @escaping (Double) -> Void) {
+            self.onScroll = onScroll
+        }
+
+        func scrollViewDidScroll(_ scrollView: UIScrollView) {
+            onScroll(scrollView.contentOffset.x)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- 読書設定に表示モード（横書きスクロール / 縦書きページ）を追加
- UITextViewベースの縦書きページビューを追加し、縦書き + 横スワイプページングを実装
- Reader画面で表示モードに応じてレンダリングを切り替え

## Issue
- Closes #23

## Test観点
- [ ] 設定で表示モードを切り替えるとReader表示が変わる
- [ ] 縦書きページモードで横スワイプのページ送りができる
- [ ] 横書きスクロールモードが既存どおり動作する
- [ ] テーマ/フォント/行間/余白の設定反映が維持される
- [ ] しおり保存がクラッシュせず継続動作する
