### PR TITLE
feat(reader): 縦書きデフォルト化とページ位置インジケータ

### DIFF
--- a/Sources/App/Models/ReadingSettings.swift
+++ b/Sources/App/Models/ReadingSettings.swift
@@ -131,7 +131,7 @@ final class ReadingSettings: @unchecked Sendable {
     private let themeKey = "readingTheme"
 
     private init() {
-        layoutMode = ReadingLayoutMode(rawValue: defaults.string(forKey: layoutModeKey) ?? "") ?? .horizontalScroll
+        layoutMode = ReadingLayoutMode(rawValue: defaults.string(forKey: layoutModeKey) ?? "") ?? .verticalPaged
         fontSize = FontSizeLevel(rawValue: defaults.integer(forKey: fontSizeKey)) ?? .medium
         lineSpacing = LineSpacingLevel(rawValue: defaults.integer(forKey: lineSpacingKey)) ?? .normal
         padding = PaddingLevel(rawValue: defaults.integer(forKey: paddingKey)) ?? .normal

--- a/Sources/Features/Reader/View/ReaderScreen.swift
+++ b/Sources/Features/Reader/View/ReaderScreen.swift
@@ -6,6 +6,8 @@ struct ReaderScreen: View {
     @State private var viewModel: ReaderViewModel
     @State private var settings = ReadingSettings.shared
     @State private var showSettings = false
+    @State private var currentPage = 1
+    @State private var totalPages = 1
     @Environment(\.modelContext) private var modelContext
 
     init(book: Book) {
@@ -29,10 +31,22 @@ struct ReaderScreen: View {
                 )
             } else if let content = viewModel.content {
                 if settings.layoutMode == .verticalPaged {
-                    VerticalPagedReaderView(content: content, settings: settings) { offset in
-                        viewModel.saveBookmark(scrollOffset: offset, context: modelContext)
+                    ZStack(alignment: .bottomTrailing) {
+                        VerticalPagedReaderView(content: content, settings: settings) { offset in
+                            viewModel.saveBookmark(scrollOffset: offset, context: modelContext)
+                        } onPageChanged: { current, total in
+                            currentPage = current
+                            totalPages = total
+                        }
+                        .background(settings.theme.backgroundColor)
+
+                        Text("\(currentPage) / \(totalPages)")
+                            .font(.caption.monospacedDigit())
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 6)
+                            .background(.ultraThinMaterial, in: Capsule())
+                            .padding()
                     }
-                    .background(settings.theme.backgroundColor)
                 } else {
                     ScrollViewReader { _ in
                         ScrollView {

--- a/Sources/Features/Reader/View/VerticalPagedReaderView.swift
+++ b/Sources/Features/Reader/View/VerticalPagedReaderView.swift
@@ -1,65 +1,148 @@
 import SwiftUI
-import UIKit
+import WebKit
 
 struct VerticalPagedReaderView: UIViewRepresentable {
     let content: AttributedString
     let settings: ReadingSettings
     let onScroll: (Double) -> Void
+    let onPageChanged: (_ current: Int, _ total: Int) -> Void
 
-    func makeUIView(context: Context) -> UITextView {
-        let textView = UITextView()
-        textView.isEditable = false
-        textView.isSelectable = true
-        textView.backgroundColor = .clear
-        textView.delegate = context.coordinator
-        textView.isPagingEnabled = true
-        textView.alwaysBounceHorizontal = true
-        textView.alwaysBounceVertical = false
-        textView.showsHorizontalScrollIndicator = false
-        textView.showsVerticalScrollIndicator = false
-        textView.textContainerInset = UIEdgeInsets(
-            top: settings.padding.value,
-            left: settings.padding.value,
-            bottom: settings.padding.value,
-            right: settings.padding.value
-        )
-        textView.textContainer.lineFragmentPadding = 0
-        textView.semanticContentAttribute = .forceRightToLeft
-        return textView
+    func makeUIView(context: Context) -> WKWebView {
+        let config = WKWebViewConfiguration()
+        let webView = WKWebView(frame: .zero, configuration: config)
+        webView.isOpaque = false
+        webView.backgroundColor = .clear
+        webView.scrollView.isPagingEnabled = true
+        webView.scrollView.showsHorizontalScrollIndicator = false
+        webView.scrollView.showsVerticalScrollIndicator = false
+        webView.scrollView.alwaysBounceHorizontal = true
+        webView.scrollView.alwaysBounceVertical = false
+        webView.navigationDelegate = context.coordinator
+        webView.scrollView.delegate = context.coordinator
+        context.coordinator.webView = webView
+        return webView
     }
 
-    func updateUIView(_ uiView: UITextView, context: Context) {
-        uiView.backgroundColor = UIColor(settings.theme.backgroundColor)
+    func updateUIView(_ webView: WKWebView, context: Context) {
+        context.coordinator.onScroll = onScroll
+        context.coordinator.onPageChanged = onPageChanged
 
-        let mutable = NSMutableAttributedString(attributedString: NSAttributedString(content))
-        let fullRange = NSRange(location: 0, length: mutable.length)
-        mutable.addAttributes([
-            .verticalGlyphForm: 1,
-            .foregroundColor: UIColor(settings.theme.textColor),
-            .font: UIFont.systemFont(ofSize: CGFloat(settings.fontSize.rawValue))
-        ], range: fullRange)
+        let plain = String(content.characters)
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+            .replacingOccurrences(of: "\n", with: "<br>")
 
-        let paragraph = NSMutableParagraphStyle()
-        paragraph.lineSpacing = settings.lineSpacing.value
-        paragraph.alignment = .natural
-        mutable.addAttribute(.paragraphStyle, value: paragraph, range: fullRange)
+        let css = """
+        <style>
+        :root { color-scheme: light dark; }
+        html, body {
+          margin: 0;
+          padding: 0;
+          width: 100%;
+          height: 100%;
+          overflow: hidden;
+          background: \(settings.theme.hexBackground);
+          color: \(settings.theme.hexText);
+          font-family: -apple-system, 'Hiragino Mincho ProN', serif;
+          -webkit-user-select: text;
+        }
+        #reader {
+          box-sizing: border-box;
+          width: 100vw;
+          height: 100vh;
+          padding: \(Int(settings.padding.value))px;
+          writing-mode: vertical-rl;
+          text-orientation: mixed;
+          font-size: \(settings.fontSize.rawValue)px;
+          line-height: \(Double(settings.fontSize.rawValue) + settings.lineSpacing.value)px;
+          overflow-x: auto;
+          overflow-y: hidden;
+          scroll-snap-type: x mandatory;
+          column-fill: auto;
+          column-width: calc(100vw - \(Int(settings.padding.value * 2))px);
+          column-gap: 0;
+          word-break: keep-all;
+        }
+        </style>
+        """
 
-        uiView.attributedText = mutable
+        let html = """
+        <html>
+        <head>
+        <meta name='viewport' content='width=device-width,initial-scale=1.0,maximum-scale=1.0,user-scalable=no'>
+        \(css)
+        </head>
+        <body>
+          <div id='reader'>\(plain)</div>
+        </body>
+        </html>
+        """
+
+        webView.loadHTMLString(html, baseURL: nil)
     }
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(onScroll: onScroll)
+        Coordinator(onScroll: onScroll, onPageChanged: onPageChanged)
     }
 
-    final class Coordinator: NSObject, UITextViewDelegate {
-        let onScroll: (Double) -> Void
+    final class Coordinator: NSObject, WKNavigationDelegate, UIScrollViewDelegate {
+        var onScroll: (Double) -> Void
+        var onPageChanged: (_ current: Int, _ total: Int) -> Void
+        weak var webView: WKWebView?
 
-        init(onScroll: @escaping (Double) -> Void) {
+        init(onScroll: @escaping (Double) -> Void, onPageChanged: @escaping (_ current: Int, _ total: Int) -> Void) {
             self.onScroll = onScroll
+            self.onPageChanged = onPageChanged
         }
 
         func scrollViewDidScroll(_ scrollView: UIScrollView) {
-            onScroll(scrollView.contentOffset.x)
+            let offset = scrollView.contentOffset.x
+            onScroll(offset)
+
+            let pageWidth = max(scrollView.bounds.width, 1)
+            let totalPages = max(Int(ceil(scrollView.contentSize.width / pageWidth)), 1)
+            let currentPage = min(max(Int(round(offset / pageWidth)) + 1, 1), totalPages)
+            onPageChanged(currentPage, totalPages)
+        }
+
+        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            let js = """
+            (function() {
+              var el = document.getElementById('reader');
+              return { width: el.scrollWidth, viewport: el.clientWidth };
+            })();
+            """
+
+            webView.evaluateJavaScript(js) { [weak self] result, _ in
+                guard let self,
+                      let dict = result as? [String: Any],
+                      let width = dict["width"] as? Double,
+                      let viewport = dict["viewport"] as? Double
+                else { return }
+
+                let total = max(Int(ceil(width / max(viewport, 1))), 1)
+                self.onPageChanged(1, total)
+            }
+        }
+    }
+}
+
+private extension ReadingTheme {
+    var hexBackground: String {
+        switch self {
+        case .light: "#FFFFFF"
+        case .dark: "#1A1A1A"
+        case .sepia: "#F4EEDF"
+        }
+    }
+
+    var hexText: String {
+        switch self {
+        case .light: "#111111"
+        case .dark: "#F7F7F7"
+        case .sepia: "#4A3929"
         }
     }
 }


### PR DESCRIPTION
## Summary
- 読書モードのデフォルトを「縦書きページ」に変更
- 縦書きビューを WebView + CSS writing-mode に刷新し、90度ずれ問題を解消
- ページめくり体験を改善（横スワイプ / ページング）
- Reader 右下に「現在ページ / 総ページ」インジケータを追加

## Issue
- Closes #25

## Test観点
- [ ] 初回起動時の読書モードが縦書きページになっている
- [ ] 縦書き表示で文字方向が崩れず読める
- [ ] 横スワイプでページ送りできる
- [ ] ページ位置UI（例: 3 / 24）が表示・更新される
- [ ] 横書きスクロールへ切替えても既存表示が動作する
- [ ] しおり保存が継続して動く
