### PR TITLE
feat(author): 著者詳細に来歴・代表作・年表・出典表示を追加

### DIFF
--- a/Sources/App/Models/AuthorBiography.swift
+++ b/Sources/App/Models/AuthorBiography.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct AuthorBiography: Sendable {
+    let extract: String
+    let description: String
+    let source: String
+}
+
+struct AuthorTimelineEntry: Identifiable, Sendable {
+    let id = UUID()
+    let year: String
+    let label: String
+}

--- a/Sources/App/Services/AuthorBiographyService.swift
+++ b/Sources/App/Services/AuthorBiographyService.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+actor AuthorBiographyService {
+    static let shared = AuthorBiographyService()
+
+    private var cache: [Int: AuthorBiography] = [:]
+
+    private init() {}
+
+    func biography(for person: Person) async -> AuthorBiography? {
+        if let cached = cache[person.id] {
+            return cached
+        }
+
+        let fullName = "\(person.lastName)\(person.firstName)"
+        guard
+            let encodedName = fullName.addingPercentEncoding(
+                withAllowedCharacters: .urlQueryAllowed
+            ),
+            let url = URL(
+                string: "https://ja.wikipedia.org/api/rest_v1/page/summary/\(encodedName)"
+            )
+        else { return nil }
+
+        do {
+            let (data, response) = try await URLSession.shared.data(from: url)
+            guard
+                let httpResponse = response as? HTTPURLResponse,
+                httpResponse.statusCode == 200
+            else { return nil }
+
+            let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+            let extract = json?["extract"] as? String ?? ""
+            let description = json?["description"] as? String ?? ""
+
+            guard !extract.isEmpty else { return nil }
+
+            let bio = AuthorBiography(
+                extract: extract,
+                description: description,
+                source: "出典: Wikipedia（ja.wikipedia.org）"
+            )
+            cache[person.id] = bio
+            return bio
+        } catch {
+            return nil
+        }
+    }
+}

--- a/Sources/Features/AuthorDetail/View/AuthorDetailScreen.swift
+++ b/Sources/Features/AuthorDetail/View/AuthorDetailScreen.swift
@@ -14,7 +14,11 @@ struct AuthorDetailScreen: View {
             VStack(alignment: .leading, spacing: 20) {
                 portraitSection
                 profileSection
+                biographySection
+                representativeWorksSection
+                timelineSection
                 worksSection
+                sourcesSection
             }
             .padding()
         }
@@ -22,6 +26,8 @@ struct AuthorDetailScreen: View {
         .navigationBarTitleDisplayMode(.inline)
         .task { await viewModel.load() }
     }
+
+    // MARK: - Portrait
 
     private var portraitSection: some View {
         HStack(spacing: 16) {
@@ -35,12 +41,14 @@ struct AuthorDetailScreen: View {
                 }
                 .frame(width: 100, height: 130)
                 .clipShape(RoundedRectangle(cornerRadius: 8))
+                .accessibilityLabel("\(person.fullName)の肖像")
             } else {
                 Image(systemName: "person.crop.rectangle")
                     .resizable()
                     .aspectRatio(contentMode: .fit)
                     .frame(width: 100, height: 130)
                     .foregroundStyle(.quaternary)
+                    .accessibilityLabel("肖像画なし")
             }
 
             VStack(alignment: .leading, spacing: 8) {
@@ -65,6 +73,8 @@ struct AuthorDetailScreen: View {
         }
     }
 
+    // MARK: - Profile
+
     @ViewBuilder
     private var profileSection: some View {
         if !person.lastNameRomaji.isEmpty {
@@ -81,6 +91,131 @@ struct AuthorDetailScreen: View {
         }
     }
 
+    // MARK: - Biography
+
+    @ViewBuilder
+    private var biographySection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("来歴")
+                .font(.headline)
+
+            if viewModel.isLoading {
+                ProgressView()
+                    .frame(maxWidth: .infinity, alignment: .center)
+            } else if let bio = viewModel.biography {
+                Text(bio.extract)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .lineSpacing(4)
+            } else {
+                Text("来歴情報はありません")
+                    .font(.subheadline)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("来歴セクション")
+    }
+
+    // MARK: - Representative Works
+
+    @ViewBuilder
+    private var representativeWorksSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("代表作")
+                .font(.headline)
+
+            if viewModel.isLoading {
+                ProgressView()
+                    .frame(maxWidth: .infinity, alignment: .center)
+            } else if viewModel.representativeWorks.isEmpty {
+                Text("代表作の情報はありません")
+                    .font(.subheadline)
+                    .foregroundStyle(.tertiary)
+            } else {
+                ForEach(viewModel.representativeWorks) { book in
+                    NavigationLink {
+                        WorkDetailScreen(book: book)
+                    } label: {
+                        HStack(spacing: 12) {
+                            Image(systemName: "book")
+                                .foregroundStyle(.blue)
+                                .frame(width: 24)
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(book.title)
+                                    .font(.subheadline)
+                                    .fontWeight(.medium)
+                                if !book.subtitle.isEmpty {
+                                    Text(book.subtitle)
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                            Spacer()
+                            Image(systemName: "chevron.right")
+                                .font(.caption)
+                                .foregroundStyle(.tertiary)
+                        }
+                        .padding(.vertical, 4)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("代表作: \(book.title)")
+                }
+            }
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+    }
+
+    // MARK: - Timeline
+
+    @ViewBuilder
+    private var timelineSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("年表")
+                .font(.headline)
+
+            if viewModel.isLoading {
+                ProgressView()
+                    .frame(maxWidth: .infinity, alignment: .center)
+            } else if viewModel.timeline.isEmpty {
+                Text("年表情報はありません")
+                    .font(.subheadline)
+                    .foregroundStyle(.tertiary)
+            } else {
+                ForEach(viewModel.timeline) { entry in
+                    HStack(alignment: .top, spacing: 12) {
+                        Text(entry.year)
+                            .font(.caption)
+                            .fontWeight(.semibold)
+                            .foregroundStyle(.blue)
+                            .frame(width: 44, alignment: .trailing)
+
+                        Circle()
+                            .fill(.blue)
+                            .frame(width: 8, height: 8)
+                            .padding(.top, 4)
+
+                        Text(entry.label)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel("\(entry.year)年、\(entry.label)")
+                }
+            }
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+    }
+
+    // MARK: - Works List
+
     private var worksSection: some View {
         VStack(alignment: .leading, spacing: 12) {
             Text("作品一覧（\(viewModel.works.count)件）")
@@ -88,6 +223,10 @@ struct AuthorDetailScreen: View {
 
             if viewModel.isLoading {
                 ProgressView()
+            } else if viewModel.works.isEmpty {
+                Text("作品情報はありません")
+                    .font(.subheadline)
+                    .foregroundStyle(.tertiary)
             } else {
                 ForEach(viewModel.works) { book in
                     NavigationLink {
@@ -103,5 +242,38 @@ struct AuthorDetailScreen: View {
                 }
             }
         }
+    }
+
+    // MARK: - Sources
+
+    @ViewBuilder
+    private var sourcesSection: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("出典")
+                .font(.caption)
+                .fontWeight(.semibold)
+                .foregroundStyle(.secondary)
+
+            Text("作品データ: 青空文庫（aozora.gr.jp）")
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+
+            if viewModel.portraitSource != nil {
+                Text("肖像画像: Wikimedia Commons")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+
+            if viewModel.biography != nil {
+                Text("来歴情報: Wikipedia（ja.wikipedia.org）")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("出典情報")
     }
 }

--- a/Sources/Features/AuthorDetail/ViewModel/AuthorDetailViewModel.swift
+++ b/Sources/Features/AuthorDetail/ViewModel/AuthorDetailViewModel.swift
@@ -5,8 +5,11 @@ import Foundation
 final class AuthorDetailViewModel {
     let person: Person
     var works: [Book] = []
+    var representativeWorks: [Book] = []
     var portraitURL: URL?
     var portraitSource: String?
+    var biography: AuthorBiography?
+    var timeline: [AuthorTimelineEntry] = []
     var isLoading = false
     var errorMessage: String?
 
@@ -20,13 +23,21 @@ final class AuthorDetailViewModel {
         isLoading = true
         async let worksTask: Void = loadWorks()
         async let portraitTask: Void = loadPortrait()
-        _ = await (worksTask, portraitTask)
+        async let biographyTask: Void = loadBiography()
+        _ = await (worksTask, portraitTask, biographyTask)
+        buildTimeline()
         isLoading = false
     }
 
     private func loadWorks() async {
         do {
-            works = try await catalogService.booksByPerson(personId: person.id)
+            let allWorks = try await catalogService.booksByPerson(personId: person.id)
+            works = allWorks
+            representativeWorks = Array(
+                allWorks
+                    .sorted { $0.releaseDate < $1.releaseDate }
+                    .prefix(5)
+            )
         } catch {
             errorMessage = error.localizedDescription
         }
@@ -37,5 +48,31 @@ final class AuthorDetailViewModel {
             portraitURL = url
             portraitSource = "出典: Wikimedia Commons"
         }
+    }
+
+    private func loadBiography() async {
+        biography = await AuthorBiographyService.shared.biography(for: person)
+    }
+
+    private func buildTimeline() {
+        var entries: [AuthorTimelineEntry] = []
+
+        let birthYear = String(person.birthDate.prefix(4))
+        if !birthYear.isEmpty, birthYear != "0000" {
+            entries.append(AuthorTimelineEntry(year: birthYear, label: "誕生"))
+        }
+
+        for work in works.sorted(by: { $0.releaseDate < $1.releaseDate }) {
+            let year = String(work.releaseDate.prefix(4))
+            guard !year.isEmpty, year != "0000" else { continue }
+            entries.append(AuthorTimelineEntry(year: year, label: "『\(work.title)』公開"))
+        }
+
+        let deathYear = String(person.deathDate.prefix(4))
+        if !deathYear.isEmpty, deathYear != "0000" {
+            entries.append(AuthorTimelineEntry(year: deathYear, label: "逝去"))
+        }
+
+        timeline = entries
     }
 }


### PR DESCRIPTION
## Summary
- Wikipedia APIから著者の来歴（概要テキスト）を取得・表示するセクションを追加
- 代表作セクション（公開日順の上位5作品）を追加
- 年表セクション（誕生・作品公開・逝去の時系列表示）を追加
- 出典表記セクション（青空文庫・Wikimedia Commons・Wikipedia）を明示
- 全セクションにデータ欠損時のフォールバックUIを実装
- アクセシビリティラベルを追加

## Test plan
- [ ] データあり著者（例: 夏目漱石）で来歴・代表作・年表が表示されること
- [ ] データなし著者でフォールバックメッセージが表示されること
- [ ] 長文来歴テキストでレイアウトが崩れないこと
- [ ] 出典セクションがデータ取得状況に応じて動的に表示されること
- [ ] VoiceOverでアクセシビリティラベルが読み上げられること

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)