### PR TITLE
feat(cover): 商業出版風の表紙デザインを導入

### DIFF
--- a/Sources/App/Models/Bookmark.swift
+++ b/Sources/App/Models/Bookmark.swift
@@ -6,13 +6,15 @@ final class Bookmark {
     @Attribute(.unique) var bookId: Int
     var title: String
     var authorName: String
+    var classification: String
     var scrollOffset: Double
     var lastReadAt: Date
 
-    init(bookId: Int, title: String, authorName: String, scrollOffset: Double) {
+    init(bookId: Int, title: String, authorName: String, classification: String = "", scrollOffset: Double) {
         self.bookId = bookId
         self.title = title
         self.authorName = authorName
+        self.classification = classification
         self.scrollOffset = scrollOffset
         lastReadAt = .now
     }

--- a/Sources/App/Models/CoverDesignPreset.swift
+++ b/Sources/App/Models/CoverDesignPreset.swift
@@ -1,0 +1,200 @@
+import SwiftUI
+
+/// ジャンル別表紙デザインプリセット
+struct CoverDesignPreset: Sendable {
+    let palette: ColorPalette
+    let pattern: CoverPattern
+    let titleFont: Font.Design
+    let authorFont: Font.Design
+
+    struct ColorPalette: Sendable {
+        let background: (red: Double, green: Double, blue: Double)
+        let gradientEnd: (red: Double, green: Double, blue: Double)
+        let accent: (red: Double, green: Double, blue: Double)
+        let text: (red: Double, green: Double, blue: Double)
+
+        var backgroundColor: Color {
+            Color(red: background.red, green: background.green, blue: background.blue)
+        }
+
+        var gradientEndColor: Color {
+            Color(red: gradientEnd.red, green: gradientEnd.green, blue: gradientEnd.blue)
+        }
+
+        var accentColor: Color {
+            Color(red: accent.red, green: accent.green, blue: accent.blue)
+        }
+
+        var textColor: Color {
+            Color(red: text.red, green: text.green, blue: text.blue)
+        }
+    }
+
+    enum CoverPattern: Sendable {
+        case literary // 文芸 — 帯+装飾ライン
+        case poetry // 詩 — 余白と繊細なライン
+        case children // 児童文学 — 丸みのあるポップ
+        case drama // 戯曲 — 劇場カーテン風
+        case essay // エッセイ — ミニマル横書き
+        case classic // デフォルト
+    }
+
+    // MARK: - Palette Variations per genre
+
+    private static let literaryPalettes: [ColorPalette] = [
+        ColorPalette(
+            background: (0.10, 0.12, 0.22),
+            gradientEnd: (0.18, 0.22, 0.38),
+            accent: (0.85, 0.72, 0.42),
+            text: (0.95, 0.93, 0.88)
+        ),
+        ColorPalette(
+            background: (0.22, 0.14, 0.12),
+            gradientEnd: (0.38, 0.22, 0.18),
+            accent: (0.90, 0.80, 0.55),
+            text: (0.95, 0.93, 0.88)
+        ),
+        ColorPalette(
+            background: (0.08, 0.18, 0.15),
+            gradientEnd: (0.14, 0.30, 0.25),
+            accent: (0.82, 0.78, 0.55),
+            text: (0.92, 0.95, 0.90)
+        ),
+        ColorPalette(
+            background: (0.18, 0.12, 0.22),
+            gradientEnd: (0.30, 0.20, 0.38),
+            accent: (0.88, 0.75, 0.50),
+            text: (0.95, 0.92, 0.95)
+        ),
+    ]
+
+    private static let poetryPalettes: [ColorPalette] = [
+        ColorPalette(
+            background: (0.28, 0.32, 0.48),
+            gradientEnd: (0.40, 0.45, 0.62),
+            accent: (0.92, 0.90, 0.82),
+            text: (0.98, 0.97, 0.95)
+        ),
+        ColorPalette(
+            background: (0.35, 0.30, 0.45),
+            gradientEnd: (0.50, 0.42, 0.60),
+            accent: (0.95, 0.88, 0.80),
+            text: (0.98, 0.96, 0.94)
+        ),
+        ColorPalette(
+            background: (0.25, 0.38, 0.42),
+            gradientEnd: (0.38, 0.52, 0.55),
+            accent: (0.95, 0.92, 0.85),
+            text: (0.98, 0.98, 0.96)
+        ),
+    ]
+
+    private static let childrenPalettes: [ColorPalette] = [
+        ColorPalette(
+            background: (0.92, 0.52, 0.20),
+            gradientEnd: (0.95, 0.68, 0.32),
+            accent: (1.0, 1.0, 1.0),
+            text: (1.0, 1.0, 1.0)
+        ),
+        ColorPalette(
+            background: (0.22, 0.62, 0.52),
+            gradientEnd: (0.32, 0.75, 0.62),
+            accent: (1.0, 0.95, 0.82),
+            text: (1.0, 1.0, 1.0)
+        ),
+        ColorPalette(
+            background: (0.55, 0.42, 0.72),
+            gradientEnd: (0.68, 0.55, 0.82),
+            accent: (1.0, 0.95, 0.85),
+            text: (1.0, 1.0, 1.0)
+        ),
+    ]
+
+    private static let dramaPalettes: [ColorPalette] = [
+        ColorPalette(
+            background: (0.42, 0.10, 0.12),
+            gradientEnd: (0.58, 0.15, 0.18),
+            accent: (0.95, 0.85, 0.55),
+            text: (0.98, 0.95, 0.90)
+        ),
+        ColorPalette(
+            background: (0.10, 0.10, 0.12),
+            gradientEnd: (0.20, 0.18, 0.25),
+            accent: (0.95, 0.82, 0.45),
+            text: (0.98, 0.96, 0.92)
+        ),
+    ]
+
+    private static let essayPalettes: [ColorPalette] = [
+        ColorPalette(
+            background: (0.93, 0.91, 0.86),
+            gradientEnd: (0.88, 0.85, 0.80),
+            accent: (0.20, 0.22, 0.28),
+            text: (0.15, 0.15, 0.18)
+        ),
+        ColorPalette(
+            background: (0.90, 0.92, 0.88),
+            gradientEnd: (0.84, 0.87, 0.82),
+            accent: (0.22, 0.28, 0.22),
+            text: (0.15, 0.18, 0.15)
+        ),
+    ]
+
+    private static let classicPalettes: [ColorPalette] = [
+        ColorPalette(
+            background: (0.15, 0.28, 0.40),
+            gradientEnd: (0.25, 0.40, 0.52),
+            accent: (0.92, 0.85, 0.68),
+            text: (0.95, 0.95, 0.92)
+        ),
+        ColorPalette(
+            background: (0.28, 0.22, 0.35),
+            gradientEnd: (0.40, 0.32, 0.48),
+            accent: (0.88, 0.82, 0.65),
+            text: (0.95, 0.93, 0.95)
+        ),
+    ]
+
+    /// タイトルから安定したハッシュを生成（hashValue は起動ごとに変わるため独自実装）
+    static func stableHash(for string: String) -> Int {
+        var hash = 5381
+        for char in string.utf8 {
+            hash = ((hash &<< 5) &+ hash) &+ Int(char)
+        }
+        return abs(hash)
+    }
+
+    /// WorkType とタイトルからプリセットを決定
+    static func preset(for workType: WorkType, title: String) -> Self {
+        let hash = Self.stableHash(for: title)
+
+        switch workType {
+        case .novel, .shortStory:
+            let palette = Self.literaryPalettes[hash % Self.literaryPalettes.count]
+            return Self(palette: palette, pattern: .literary, titleFont: .serif, authorFont: .default)
+        case .poetry:
+            let palette = Self.poetryPalettes[hash % Self.poetryPalettes.count]
+            return Self(palette: palette, pattern: .poetry, titleFont: .serif, authorFont: .serif)
+        case .childrenLiterature:
+            let palette = Self.childrenPalettes[hash % Self.childrenPalettes.count]
+            return Self(palette: palette, pattern: .children, titleFont: .rounded, authorFont: .rounded)
+        case .drama:
+            let palette = Self.dramaPalettes[hash % Self.dramaPalettes.count]
+            return Self(palette: palette, pattern: .drama, titleFont: .serif, authorFont: .default)
+        case .essay:
+            let palette = Self.essayPalettes[hash % Self.essayPalettes.count]
+            return Self(palette: palette, pattern: .essay, titleFont: .default, authorFont: .default)
+        case .other:
+            let palette = Self.classicPalettes[hash % Self.classicPalettes.count]
+            return Self(palette: palette, pattern: .classic, titleFont: .serif, authorFont: .default)
+        }
+    }
+
+    /// フォールバック用のデフォルトプリセット
+    static let fallback = Self(
+        palette: Self.classicPalettes[0],
+        pattern: .classic,
+        titleFont: .serif,
+        authorFont: .default
+    )
+}

--- a/Sources/Features/AuthorDetail/View/AuthorDetailScreen.swift
+++ b/Sources/Features/AuthorDetail/View/AuthorDetailScreen.swift
@@ -93,7 +93,6 @@ struct AuthorDetailScreen: View {
 
     // MARK: - Biography
 
-    @ViewBuilder
     private var biographySection: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text("来歴")
@@ -122,7 +121,6 @@ struct AuthorDetailScreen: View {
 
     // MARK: - Representative Works
 
-    @ViewBuilder
     private var representativeWorksSection: some View {
         VStack(alignment: .leading, spacing: 12) {
             Text("代表作")
@@ -173,7 +171,6 @@ struct AuthorDetailScreen: View {
 
     // MARK: - Timeline
 
-    @ViewBuilder
     private var timelineSection: some View {
         VStack(alignment: .leading, spacing: 12) {
             Text("年表")
@@ -246,7 +243,6 @@ struct AuthorDetailScreen: View {
 
     // MARK: - Sources
 
-    @ViewBuilder
     private var sourcesSection: some View {
         VStack(alignment: .leading, spacing: 4) {
             Text("出典")

--- a/Sources/Features/Home/View/HomeScreen.swift
+++ b/Sources/Features/Home/View/HomeScreen.swift
@@ -157,45 +157,15 @@ private struct ShelfSection<Content: View>: View {
 private struct ContinueReadingCard: View {
     let bookmark: Bookmark
 
-    private var coverColor: Color {
-        BookCoverView.coverColor(forTitle: bookmark.title)
-    }
-
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
-            ZStack(alignment: .bottom) {
-                RoundedRectangle(cornerRadius: 8)
-                    .fill(coverColor.gradient)
-                    .frame(width: 110, height: 155)
-
-                // Spine accent
-                HStack(spacing: 0) {
-                    Rectangle()
-                        .fill(.white.opacity(0.15))
-                        .frame(width: 3)
-                    Spacer()
-                }
-                .frame(width: 110, height: 155)
-                .clipShape(RoundedRectangle(cornerRadius: 8))
-
-                VStack(spacing: 4) {
-                    Text(bookmark.title)
-                        .font(.system(size: 13, weight: .bold, design: .serif))
-                        .foregroundStyle(.white)
-                        .lineLimit(4)
-                        .multilineTextAlignment(.center)
-                        .shadow(color: .black.opacity(0.3), radius: 1, y: 1)
-
-                    Text(bookmark.authorName)
-                        .font(.system(size: 9, weight: .medium))
-                        .foregroundStyle(.white.opacity(0.8))
-                        .lineLimit(1)
-                }
-                .padding(.horizontal, 10)
-                .padding(.vertical, 12)
-                .frame(width: 110)
-            }
-            .shadow(color: .black.opacity(0.2), radius: 4, x: 2, y: 3)
+            BookCoverView(
+                title: bookmark.title,
+                authorName: bookmark.authorName,
+                classification: bookmark.classification,
+                width: 110,
+                height: 155
+            )
 
             Text(bookmark.title)
                 .font(.subheadline)

--- a/Sources/Features/Reader/ViewModel/ReaderViewModel.swift
+++ b/Sources/Features/Reader/ViewModel/ReaderViewModel.swift
@@ -63,6 +63,7 @@ final class ReaderViewModel {
                 bookId: book.id,
                 title: book.title,
                 authorName: book.authorName,
+                classification: book.classification,
                 scrollOffset: scrollOffset
             )
             context.insert(bookmark)

--- a/Sources/Features/Search/View/BookCoverView.swift
+++ b/Sources/Features/Search/View/BookCoverView.swift
@@ -1,69 +1,322 @@
 import SwiftUI
 
 struct BookCoverView: View {
-    let book: Book
+    let title: String
+    let authorName: String
+    let classification: String
     var width: CGFloat = 60
     var height: CGFloat = 85
 
-    static func coverColor(forTitle title: String) -> Color {
-        let hash = abs(title.hashValue)
-        let colors: [Color] = [
-            Color(red: 0.2, green: 0.4, blue: 0.6),
-            Color(red: 0.6, green: 0.3, blue: 0.3),
-            Color(red: 0.3, green: 0.5, blue: 0.3),
-            Color(red: 0.5, green: 0.4, blue: 0.6),
-            Color(red: 0.6, green: 0.5, blue: 0.3),
-            Color(red: 0.4, green: 0.5, blue: 0.5),
-            Color(red: 0.5, green: 0.3, blue: 0.5),
-            Color(red: 0.3, green: 0.4, blue: 0.5),
-        ]
-        return colors[hash % colors.count]
+    init(book: Book, width: CGFloat = 60, height: CGFloat = 85) {
+        title = book.title
+        authorName = book.authorName
+        classification = book.classification
+        self.width = width
+        self.height = height
     }
 
-    private var coverColor: Color {
-        Self.coverColor(forTitle: book.title)
+    init(title: String, authorName: String, classification: String = "", width: CGFloat = 60, height: CGFloat = 85) {
+        self.title = title
+        self.authorName = authorName
+        self.classification = classification
+        self.width = width
+        self.height = height
+    }
+
+    private var workType: WorkType {
+        WorkType.from(classification: classification)
+    }
+
+    private var preset: CoverDesignPreset {
+        CoverDesignPreset.preset(for: workType, title: title)
     }
 
     private var isLarge: Bool {
         width >= 90
     }
 
+    private var isMedium: Bool {
+        width >= 60
+    }
+
     var body: some View {
-        ZStack(alignment: .bottom) {
-            RoundedRectangle(cornerRadius: 8)
-                .fill(coverColor.gradient)
+        ZStack {
+            // Background gradient
+            RoundedRectangle(cornerRadius: isLarge ? 6 : 4)
+                .fill(
+                    LinearGradient(
+                        colors: [preset.palette.backgroundColor, preset.palette.gradientEndColor],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
 
-            // Spine accent
-            HStack(spacing: 0) {
-                Rectangle()
-                    .fill(.white.opacity(0.15))
-                    .frame(width: 3)
-                Spacer()
-            }
-            .clipShape(RoundedRectangle(cornerRadius: 8))
+            // Pattern overlay
+            patternOverlay
 
-            // Title area
-            VStack(spacing: 4) {
-                Spacer()
-
-                Text(book.title)
-                    .font(.system(size: isLarge ? 13 : 10, weight: .bold, design: .serif))
-                    .foregroundStyle(.white)
-                    .lineLimit(isLarge ? 4 : 2)
-                    .multilineTextAlignment(.center)
-                    .shadow(color: .black.opacity(0.3), radius: 1, y: 1)
-
-                Text(book.authorName)
-                    .font(.system(size: isLarge ? 9 : 7, weight: .medium))
-                    .foregroundStyle(.white.opacity(0.8))
-                    .lineLimit(1)
-
-                Spacer()
-            }
-            .padding(.horizontal, isLarge ? 10 : 6)
-            .padding(.vertical, isLarge ? 12 : 6)
+            // Content layout
+            contentLayout
         }
         .frame(width: width, height: height)
-        .shadow(color: .black.opacity(0.2), radius: 4, x: 2, y: 3)
+        .clipShape(RoundedRectangle(cornerRadius: isLarge ? 6 : 4))
+        .overlay(
+            // Spine + edge highlight
+            HStack(spacing: 0) {
+                Rectangle()
+                    .fill(
+                        LinearGradient(
+                            colors: [.white.opacity(0.25), .white.opacity(0.05)],
+                            startPoint: .leading,
+                            endPoint: .trailing
+                        )
+                    )
+                    .frame(width: isLarge ? 4 : 3)
+                Spacer()
+            }
+            .clipShape(RoundedRectangle(cornerRadius: isLarge ? 6 : 4))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: isLarge ? 6 : 4)
+                .strokeBorder(.black.opacity(0.12), lineWidth: 0.5)
+        )
+        .shadow(color: .black.opacity(0.25), radius: isLarge ? 6 : 3, x: 2, y: 3)
+    }
+
+    // MARK: - Pattern Overlay
+
+    @ViewBuilder
+    private var patternOverlay: some View {
+        switch preset.pattern {
+        case .literary:
+            literaryPattern
+        case .poetry:
+            poetryPattern
+        case .children:
+            childrenPattern
+        case .drama:
+            dramaPattern
+        case .essay:
+            essayPattern
+        case .classic:
+            classicPattern
+        }
+    }
+
+    private var literaryPattern: some View {
+        VStack(spacing: 0) {
+            Spacer()
+            // 帯（obi）装飾
+            Rectangle()
+                .fill(preset.palette.accentColor.opacity(0.9))
+                .frame(height: height * 0.12)
+                .overlay(alignment: .top) {
+                    Rectangle()
+                        .fill(.white.opacity(0.3))
+                        .frame(height: 0.5)
+                }
+                .overlay(alignment: .bottom) {
+                    Rectangle()
+                        .fill(.white.opacity(0.3))
+                        .frame(height: 0.5)
+                }
+                .offset(y: -height * 0.18)
+            Spacer()
+                .frame(height: height * 0.18)
+        }
+    }
+
+    private var poetryPattern: some View {
+        VStack(spacing: 0) {
+            // 上部の繊細な装飾ライン
+            Spacer()
+                .frame(height: height * 0.15)
+            HStack {
+                Spacer()
+                Rectangle()
+                    .fill(preset.palette.accentColor.opacity(0.25))
+                    .frame(width: width * 0.45, height: 0.5)
+                Spacer()
+            }
+            Spacer()
+            HStack {
+                Spacer()
+                Rectangle()
+                    .fill(preset.palette.accentColor.opacity(0.25))
+                    .frame(width: width * 0.45, height: 0.5)
+                Spacer()
+            }
+            Spacer()
+                .frame(height: height * 0.15)
+        }
+    }
+
+    private var childrenPattern: some View {
+        GeometryReader { geo in
+            // ポップな丸ドット装飾
+            let dotSize: CGFloat = isLarge ? 8 : 5
+            ForEach(0 ..< 4, id: \.self) { i in
+                Circle()
+                    .fill(preset.palette.accentColor.opacity(0.12))
+                    .frame(width: dotSize, height: dotSize)
+                    .position(dotPosition(index: i, in: geo.size))
+            }
+        }
+    }
+
+    private func dotPosition(index: Int, in size: CGSize) -> CGPoint {
+        let positions: [(CGFloat, CGFloat)] = [
+            (0.8, 0.12), (0.15, 0.25), (0.85, 0.78), (0.2, 0.88),
+        ]
+        let pos = positions[index % positions.count]
+        return CGPoint(x: size.width * pos.0, y: size.height * pos.1)
+    }
+
+    private var dramaPattern: some View {
+        VStack(spacing: 0) {
+            // 劇場カーテン風のトップ装飾
+            Rectangle()
+                .fill(
+                    LinearGradient(
+                        colors: [
+                            preset.palette.accentColor.opacity(0.15),
+                            .clear,
+                        ],
+                        startPoint: .top,
+                        endPoint: .bottom
+                    )
+                )
+                .frame(height: height * 0.2)
+            Spacer()
+        }
+    }
+
+    private var essayPattern: some View {
+        VStack(spacing: 0) {
+            Spacer()
+            // 底部のアクセントライン
+            HStack {
+                Rectangle()
+                    .fill(preset.palette.accentColor.opacity(0.6))
+                    .frame(width: width * 0.4, height: 2)
+                Spacer()
+            }
+            .padding(.leading, isLarge ? 14 : 8)
+            .padding(.bottom, isLarge ? 14 : 8)
+        }
+    }
+
+    private var classicPattern: some View {
+        VStack(spacing: 0) {
+            // シンプルな上下ボーダー
+            Rectangle()
+                .fill(preset.palette.accentColor.opacity(0.3))
+                .frame(height: 1)
+                .padding(.horizontal, isLarge ? 12 : 8)
+                .padding(.top, isLarge ? 10 : 6)
+            Spacer()
+            Rectangle()
+                .fill(preset.palette.accentColor.opacity(0.3))
+                .frame(height: 1)
+                .padding(.horizontal, isLarge ? 12 : 8)
+                .padding(.bottom, isLarge ? 10 : 6)
+        }
+    }
+
+    // MARK: - Content Layout
+
+    @ViewBuilder
+    private var contentLayout: some View {
+        if preset.pattern == .essay {
+            essayContentLayout
+        } else {
+            defaultContentLayout
+        }
+    }
+
+    private var defaultContentLayout: some View {
+        VStack(spacing: isLarge ? 6 : 3) {
+            Spacer()
+
+            Text(title)
+                .font(.system(
+                    size: titleFontSize,
+                    weight: .bold,
+                    design: preset.titleFont
+                ))
+                .foregroundStyle(preset.palette.textColor)
+                .lineLimit(isLarge ? 4 : isMedium ? 3 : 2)
+                .multilineTextAlignment(.center)
+                .shadow(color: .black.opacity(0.4), radius: 1, y: 1)
+
+            if isMedium {
+                Text(authorName)
+                    .font(.system(
+                        size: authorFontSize,
+                        weight: .medium,
+                        design: preset.authorFont
+                    ))
+                    .foregroundStyle(preset.palette.textColor.opacity(0.75))
+                    .lineLimit(1)
+            }
+
+            Spacer()
+        }
+        .padding(.horizontal, isLarge ? 12 : isMedium ? 8 : 5)
+        .padding(.vertical, isLarge ? 14 : 8)
+    }
+
+    private var essayContentLayout: some View {
+        VStack(alignment: .leading, spacing: isLarge ? 6 : 3) {
+            Spacer()
+                .frame(height: height * 0.2)
+
+            Text(title)
+                .font(.system(
+                    size: titleFontSize,
+                    weight: .semibold,
+                    design: preset.titleFont
+                ))
+                .foregroundStyle(preset.palette.textColor)
+                .lineLimit(isLarge ? 4 : 3)
+                .multilineTextAlignment(.leading)
+
+            if isMedium {
+                Text(authorName)
+                    .font(.system(
+                        size: authorFontSize,
+                        weight: .regular,
+                        design: preset.authorFont
+                    ))
+                    .foregroundStyle(preset.palette.textColor.opacity(0.65))
+                    .lineLimit(1)
+            }
+
+            Spacer()
+        }
+        .padding(.horizontal, isLarge ? 14 : 8)
+        .padding(.vertical, isLarge ? 10 : 6)
+    }
+
+    // MARK: - Font Sizes
+
+    private var titleFontSize: CGFloat {
+        if isLarge { return 14 }
+        if isMedium { return 11 }
+        return 9
+    }
+
+    private var authorFontSize: CGFloat {
+        if isLarge { return 10 }
+        return 8
+    }
+}
+
+// MARK: - Legacy Color Helper (for non-Book contexts)
+
+extension BookCoverView {
+    static func coverColor(forTitle title: String) -> Color {
+        let workType = WorkType.other
+        let preset = CoverDesignPreset.preset(for: workType, title: title)
+        return preset.palette.backgroundColor
     }
 }


### PR DESCRIPTION
## Summary
- ジャンル別の表紙デザインプリセット（文芸/詩/児童文学/戯曲/エッセイ/その他）を追加
- CoverImageService にプリセットキャッシュを追加
- ホーム/検索/読書導線で表紙表示を統一
- 生成失敗時フォールバックを追加

## Issue
- Closes #40

## Test観点
- [ ] ジャンルごとに表紙トーンが変わる
- [ ] 同一作品の再表示が安定（キャッシュ有効）
- [ ] 分類不明でもフォールバック表示される
- [ ] 棚画面と詳細画面で表紙見た目が統一される