### PR TITLE
feat(reader): 禁則処理改善とページ単位のしおり復元

### DIFF
--- a/Sources/Features/Reader/View/ReaderScreen.swift
+++ b/Sources/Features/Reader/View/ReaderScreen.swift
@@ -32,8 +32,12 @@ struct ReaderScreen: View {
             } else if let content = viewModel.content {
                 if settings.layoutMode == .verticalPaged {
                     ZStack(alignment: .bottomTrailing) {
-                        VerticalPagedReaderView(content: content, settings: settings) { offset in
-                            viewModel.saveBookmark(scrollOffset: offset, context: modelContext)
+                        VerticalPagedReaderView(
+                            content: content,
+                            settings: settings,
+                            savedPageRatio: viewModel.savedScrollOffset
+                        ) { ratio in
+                            viewModel.saveBookmark(scrollOffset: ratio, context: modelContext)
                         } onPageChanged: { current, total in
                             currentPage = current
                             totalPages = total


### PR DESCRIPTION
## Summary
- CSS `line-break: strict` で JIS X 4051 準拠の禁則処理を適用し、句読点・約物の不自然な改行を改善
- しおりをピクセル座標からページ比率(0.0-1.0)に変更し、設定変更後も同じ位置に復帰可能に
- ページインジケータの精度を改善（HTML読込中のスクロールイベント無視で比率の破損を防止）

## Test plan
- [ ] 長文作品（走れメロスなど）を開き、句読点が行頭に来ないことを確認
- [ ] 途中のページでアプリを閉じ、再度開いて同じ位置に復帰することを確認
- [ ] フォントサイズ・余白を変更した後、読書位置が比率的に保持されることを確認
- [ ] ページ数表示が実態と大きくズレないことを確認
- [ ] 旧バージョンのブックマーク（ピクセル値）がある場合にクラッシュしないことを確認

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)