### PR TITLE
test(core): Home棚ロジックとRecommendationServiceの回帰テストを追加

### DIFF
--- a/Sources/App/Services/RecommendationService.swift
+++ b/Sources/App/Services/RecommendationService.swift
@@ -48,7 +48,7 @@ final class RecommendationService {
 
     // MARK: - Scoring
 
-    private func accumulateHistoryScores(
+    func accumulateHistoryScores(
         _ histories: [ReadingHistory],
         topClassification: String,
         scores: inout [Int: Double],
@@ -88,7 +88,7 @@ final class RecommendationService {
         }
     }
 
-    private func applyRecencyDecay(scores: inout [Int: Double], latestInteraction: [Int: Date]) {
+    func applyRecencyDecay(scores: inout [Int: Double], latestInteraction: [Int: Date]) {
         let now = Date.now
         for (personId, lastDate) in latestInteraction {
             let days = now.timeIntervalSince(lastDate) / 86400
@@ -136,7 +136,7 @@ final class RecommendationService {
         return (try? context.fetch(descriptor)) ?? []
     }
 
-    private func mostViewedClassification(histories: [ReadingHistory]) -> String {
+    func mostViewedClassification(histories: [ReadingHistory]) -> String {
         var counts: [String: Int] = [:]
         for history in histories where !history.classification.isEmpty {
             counts[history.classification, default: 0] += history.viewCount

--- a/Sources/Features/Home/ViewModel/HomeViewModel.swift
+++ b/Sources/Features/Home/ViewModel/HomeViewModel.swift
@@ -30,9 +30,9 @@ final class HomeViewModel {
         await loadAuthorPortraits()
     }
 
-    // MARK: - Private
+    // MARK: - Internal (testable)
 
-    private func loadContinueReading(context: ModelContext) -> [Bookmark] {
+    func loadContinueReading(context: ModelContext) -> [Bookmark] {
         var descriptor = FetchDescriptor<Bookmark>(
             sortBy: [SortDescriptor(\.lastReadAt, order: .reverse)]
         )
@@ -44,7 +44,7 @@ final class HomeViewModel {
         await RecommendationService.shared.recommendAuthors(context: context)
     }
 
-    private func loadRecentReviews(context: ModelContext) -> [BookReview] {
+    func loadRecentReviews(context: ModelContext) -> [BookReview] {
         var descriptor = FetchDescriptor<BookReview>(
             sortBy: [SortDescriptor(\.updatedAt, order: .reverse)]
         )

--- a/Tests/HomeViewModelTests.swift
+++ b/Tests/HomeViewModelTests.swift
@@ -1,0 +1,118 @@
+@testable import App
+import Foundation
+import SwiftData
+import Testing
+
+@MainActor
+@Suite("HomeViewModel 棚構築ロジック")
+struct HomeViewModelTests {
+    private func makeContainer() throws -> ModelContainer {
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        return try ModelContainer(
+            for: Bookmark.self,
+            BookReview.self,
+            ReadingHistory.self,
+            FavoriteBook.self,
+            GeneratedSummary.self,
+            configurations: config
+        )
+    }
+
+    // MARK: - Continue Reading
+
+    @Test("読書中の棚: ブックマークを lastReadAt 降順で返す")
+    func continueReadingSortedByLastReadDesc() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+
+        let b1 = Bookmark(bookId: 1, title: "古い本", authorName: "著者A", scrollOffset: 0)
+        b1.lastReadAt = Date(timeIntervalSince1970: 1000)
+        let b2 = Bookmark(bookId: 2, title: "新しい本", authorName: "著者B", scrollOffset: 0)
+        b2.lastReadAt = Date(timeIntervalSince1970: 2000)
+        context.insert(b1)
+        context.insert(b2)
+        try context.save()
+
+        let vm = HomeViewModel()
+        let result = vm.loadContinueReading(context: context)
+
+        #expect(result.count == 2)
+        #expect(result[0].bookId == 2)
+        #expect(result[1].bookId == 1)
+    }
+
+    @Test("読書中の棚: 上限10件")
+    func continueReadingLimitsTo10() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+
+        for i in 1 ... 15 {
+            let bookmark = Bookmark(bookId: i, title: "本\(i)", authorName: "著者", scrollOffset: 0)
+            bookmark.lastReadAt = Date(timeIntervalSince1970: Double(i) * 1000)
+            context.insert(bookmark)
+        }
+        try context.save()
+
+        let vm = HomeViewModel()
+        let result = vm.loadContinueReading(context: context)
+
+        #expect(result.count == 10)
+    }
+
+    @Test("読書中の棚: ブックマーク0件で空配列")
+    func continueReadingEmptyWhenNoBookmarks() throws {
+        let container = try makeContainer()
+        let vm = HomeViewModel()
+        let result = vm.loadContinueReading(context: container.mainContext)
+        #expect(result.isEmpty)
+    }
+
+    // MARK: - Recent Reviews
+
+    @Test("レビュー棚: updatedAt 降順で返す")
+    func recentReviewsSortedByUpdatedAtDesc() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+
+        let r1 = BookReview(bookId: 1, title: "本A", authorName: "著者A", rating: 4, comment: "良い")
+        r1.updatedAt = Date(timeIntervalSince1970: 1000)
+        let r2 = BookReview(bookId: 2, title: "本B", authorName: "著者B", rating: 5, comment: "最高")
+        r2.updatedAt = Date(timeIntervalSince1970: 2000)
+        context.insert(r1)
+        context.insert(r2)
+        try context.save()
+
+        let vm = HomeViewModel()
+        let result = vm.loadRecentReviews(context: context)
+
+        #expect(result.count == 2)
+        #expect(result[0].bookId == 2)
+        #expect(result[1].bookId == 1)
+    }
+
+    @Test("レビュー棚: 上限10件")
+    func recentReviewsLimitsTo10() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+
+        for i in 1 ... 15 {
+            let review = BookReview(bookId: i, title: "本\(i)", authorName: "著者", rating: 3, comment: "普通")
+            review.updatedAt = Date(timeIntervalSince1970: Double(i) * 1000)
+            context.insert(review)
+        }
+        try context.save()
+
+        let vm = HomeViewModel()
+        let result = vm.loadRecentReviews(context: context)
+
+        #expect(result.count == 10)
+    }
+
+    @Test("レビュー棚: レビュー0件で空配列")
+    func recentReviewsEmptyWhenNoReviews() throws {
+        let container = try makeContainer()
+        let vm = HomeViewModel()
+        let result = vm.loadRecentReviews(context: container.mainContext)
+        #expect(result.isEmpty)
+    }
+}

--- a/Tests/RecommendationServiceTests.swift
+++ b/Tests/RecommendationServiceTests.swift
@@ -1,0 +1,234 @@
+@testable import App
+import Foundation
+import SwiftData
+import Testing
+
+@MainActor
+@Suite("RecommendationService スコアリング")
+struct RecommendationServiceTests {
+    private let service = RecommendationService.shared
+
+    // MARK: - mostViewedClassification
+
+    @Test("最頻分類: viewCount 合計が最大の分類を返す")
+    func mostViewedClassificationReturnsTop() {
+        let histories = [
+            makeHistory(bookId: 1, classification: "短編", viewCount: 3),
+            makeHistory(bookId: 2, classification: "長編", viewCount: 1),
+            makeHistory(bookId: 3, classification: "短編", viewCount: 2),
+        ]
+        let result = service.mostViewedClassification(histories: histories)
+        #expect(result == "短編") // 3 + 2 = 5 > 1
+    }
+
+    @Test("最頻分類: 履歴なしで空文字")
+    func mostViewedClassificationEmptyForNoHistory() {
+        let result = service.mostViewedClassification(histories: [])
+        #expect(result.isEmpty)
+    }
+
+    @Test("最頻分類: 空文字の分類は無視される")
+    func mostViewedClassificationIgnoresEmptyClassification() {
+        let histories = [
+            makeHistory(bookId: 1, classification: "", viewCount: 10),
+            makeHistory(bookId: 2, classification: "短編", viewCount: 1),
+        ]
+        let result = service.mostViewedClassification(histories: histories)
+        #expect(result == "短編")
+    }
+
+    // MARK: - accumulateHistoryScores
+
+    @Test("履歴スコア: viewCount + 分類ボーナスが加算される")
+    func historyScoresAccumulateCorrectly() {
+        let histories = [
+            makeHistory(bookId: 1, authorPersonId: 100, classification: "短編", viewCount: 3),
+            makeHistory(bookId: 2, authorPersonId: 100, classification: "長編", viewCount: 2),
+            makeHistory(bookId: 3, authorPersonId: 200, classification: "短編", viewCount: 1),
+        ]
+        var scores: [Int: Double] = [:]
+        var latest: [Int: Date] = [:]
+
+        service.accumulateHistoryScores(
+            histories,
+            topClassification: "短編",
+            scores: &scores,
+            latest: &latest
+        )
+
+        // Person 100: viewScore(3) + bonus(2) + viewScore(2) + bonus(0) = 7
+        #expect(scores[100] == 7)
+        // Person 200: viewScore(1) + bonus(2) = 3
+        #expect(scores[200] == 3)
+    }
+
+    @Test("履歴スコア: viewCount は5で頭打ち")
+    func historyScoresCapsViewCountAt5() {
+        let histories = [
+            makeHistory(bookId: 1, authorPersonId: 100, classification: "短編", viewCount: 10),
+        ]
+        var scores: [Int: Double] = [:]
+        var latest: [Int: Date] = [:]
+
+        service.accumulateHistoryScores(
+            histories,
+            topClassification: "長編",
+            scores: &scores,
+            latest: &latest
+        )
+
+        // min(10, 5) = 5, no classification bonus
+        #expect(scores[100] == 5)
+    }
+
+    @Test("履歴スコア: 同一著者の複数作品で累積される")
+    func historyScoresAccumulateAcrossWorks() {
+        let histories = [
+            makeHistory(bookId: 1, authorPersonId: 100, classification: "短編", viewCount: 2),
+            makeHistory(bookId: 2, authorPersonId: 100, classification: "短編", viewCount: 3),
+        ]
+        var scores: [Int: Double] = [:]
+        var latest: [Int: Date] = [:]
+
+        service.accumulateHistoryScores(
+            histories,
+            topClassification: "短編",
+            scores: &scores,
+            latest: &latest
+        )
+
+        // (2 + 2) + (3 + 2) = 9
+        #expect(scores[100] == 9)
+    }
+
+    @Test("履歴スコア: latestInteraction が最新日付で更新される")
+    func historyScoresTrackLatestInteraction() {
+        let earlier = Date(timeIntervalSince1970: 1000)
+        let later = Date(timeIntervalSince1970: 2000)
+        let h1 = makeHistory(bookId: 1, authorPersonId: 100, classification: "", viewCount: 1)
+        h1.lastViewedAt = earlier
+        let h2 = makeHistory(bookId: 2, authorPersonId: 100, classification: "", viewCount: 1)
+        h2.lastViewedAt = later
+
+        var scores: [Int: Double] = [:]
+        var latest: [Int: Date] = [:]
+
+        service.accumulateHistoryScores(
+            [h1, h2],
+            topClassification: "",
+            scores: &scores,
+            latest: &latest
+        )
+
+        #expect(latest[100] == later)
+    }
+
+    // MARK: - applyRecencyDecay
+
+    @Test("経過減衰: 直近はほぼ減衰なし、45日で50%")
+    func recencyDecayAppliesCorrectly() throws {
+        let now = Date.now
+        var scores: [Int: Double] = [100: 10.0, 200: 10.0]
+        let latestInteraction: [Int: Date] = [
+            100: now,
+            200: now.addingTimeInterval(-45 * 86400),
+        ]
+
+        service.applyRecencyDecay(scores: &scores, latestInteraction: latestInteraction)
+
+        #expect(try #require(scores[100]) > 9.9) // ~10.0
+        #expect(scores[200] == 5.0) // 10.0 * 0.5
+    }
+
+    @Test("経過減衰: 90日超でも50%が下限")
+    func recencyDecayFlooredAt50Percent() {
+        let now = Date.now
+        var scores = [100: 10.0]
+        let latestInteraction: [Int: Date] = [
+            100: now.addingTimeInterval(-365 * 86400),
+        ]
+
+        service.applyRecencyDecay(scores: &scores, latestInteraction: latestInteraction)
+
+        #expect(scores[100] == 5.0) // max(0.5, 1.0 - 365/90) = 0.5
+    }
+
+    @Test("経過減衰: 30日で約66%維持")
+    func recencyDecayAt30Days() throws {
+        let now = Date.now
+        var scores = [100: 9.0]
+        let latestInteraction: [Int: Date] = [
+            100: now.addingTimeInterval(-30 * 86400),
+        ]
+
+        service.applyRecencyDecay(scores: &scores, latestInteraction: latestInteraction)
+
+        // max(0.5, 1.0 - 30/90) = max(0.5, 0.667) = 0.667
+        let expected = 9.0 * (1.0 - 30.0 / 90.0)
+        #expect(try abs(#require(scores[100]) - expected) < 0.01)
+    }
+
+    // MARK: - Cold Start (統合)
+
+    @Test("コールドスタート: 履歴+レビュー 3件未満でフォールバック")
+    func coldStartReturnsFallback() async throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+
+        // 2件だけ挿入（< 3 → cold start）
+        context.insert(ReadingHistory(
+            bookId: 1,
+            authorPersonId: 1,
+            title: "本A",
+            authorName: "著者A",
+            classification: "短編"
+        ))
+        try context.save()
+
+        let result = await service.recommendAuthors(context: context)
+        // フォールバック結果は isFallback == true
+        for author in result {
+            #expect(author.isFallback == true)
+        }
+    }
+
+    @Test("コールドスタート: 履歴0件・レビュー0件でフォールバック")
+    func coldStartEmptyDataReturnsFallback() async throws {
+        let container = try makeContainer()
+        let result = await service.recommendAuthors(context: container.mainContext)
+        for author in result {
+            #expect(author.isFallback == true)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func makeContainer() throws -> ModelContainer {
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        return try ModelContainer(
+            for: Bookmark.self,
+            BookReview.self,
+            ReadingHistory.self,
+            FavoriteBook.self,
+            GeneratedSummary.self,
+            configurations: config
+        )
+    }
+
+    private func makeHistory(
+        bookId: Int,
+        authorPersonId: Int = 1,
+        classification: String = "",
+        viewCount: Int = 1
+    ) -> ReadingHistory {
+        let history = ReadingHistory(
+            bookId: bookId,
+            authorPersonId: authorPersonId,
+            title: "本\(bookId)",
+            authorName: "著者",
+            classification: classification
+        )
+        history.viewCount = viewCount
+        return history
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -39,5 +39,6 @@ targets:
       - target: App
     settings:
       base:
+        GENERATE_INFOPLIST_FILE: YES
         BUNDLE_LOADER: "$(TEST_HOST)"
         TEST_HOST: "$(BUILT_PRODUCTS_DIR)/App.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/App"


### PR DESCRIPTION
## Summary
- HomeViewModel の棚構築ロジック（読書中・レビュー棚）のユニットテストを追加（6テスト）
- RecommendationService のスコアリングロジックの回帰テストを追加（12テスト）
- 主要分岐（履歴なし/レビューあり/作品タイプ分類/コールドスタート）をカバー
- テストターゲットに GENERATE_INFOPLIST_FILE 設定を追加

## Test plan
- [x] 全18テストが iOS Simulator 上で通過
- [x] SwiftLint / SwiftFormat 違反なし
- [ ] CI でテストが通ることを確認

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)