### PR TITLE
perf(ui): ホーム棚の表示パフォーマンス最適化

### DIFF
--- a/Sources/Features/Search/View/BookCoverView.swift
+++ b/Sources/Features/Search/View/BookCoverView.swift
@@ -6,6 +6,7 @@ struct BookCoverView: View {
     let classification: String
     var width: CGFloat = 60
     var height: CGFloat = 85
+    private let preset: CoverDesignPreset
 
     init(book: Book, width: CGFloat = 60, height: CGFloat = 85) {
         title = book.title
@@ -13,6 +14,8 @@ struct BookCoverView: View {
         classification = book.classification
         self.width = width
         self.height = height
+        let workType = WorkType.from(classification: book.classification)
+        preset = CoverDesignPreset.preset(for: workType, title: book.title)
     }
 
     init(title: String, authorName: String, classification: String = "", width: CGFloat = 60, height: CGFloat = 85) {
@@ -21,14 +24,8 @@ struct BookCoverView: View {
         self.classification = classification
         self.width = width
         self.height = height
-    }
-
-    private var workType: WorkType {
-        WorkType.from(classification: classification)
-    }
-
-    private var preset: CoverDesignPreset {
-        CoverDesignPreset.preset(for: workType, title: title)
+        let workType = WorkType.from(classification: classification)
+        preset = CoverDesignPreset.preset(for: workType, title: title)
     }
 
     private var isLarge: Bool {
@@ -80,6 +77,7 @@ struct BookCoverView: View {
                 .strokeBorder(.black.opacity(0.12), lineWidth: 0.5)
         )
         .shadow(color: .black.opacity(0.25), radius: isLarge ? 6 : 3, x: 2, y: 3)
+        .drawingGroup(opaque: false)
     }
 
     // MARK: - Pattern Overlay


### PR DESCRIPTION
## Summary
- BookCoverView のプリセット計算をinitでキャッシュ化（毎フレーム再計算を排除）
- `drawingGroup()` で複雑なグラデーション+パターンのレンダリングをGPUに委譲しスクロール性能を改善
- Home画面を段階的表示に変更（読書中・レビュー棚を即時表示、著者・ジャンル棚はバックグラウンド追加）
- ジャンル棚ロードを逐次から `TaskGroup` による並行ロードに変更（6棚同時取得）

## Test plan
- [x] 全18テストが通過（機能退行なし）
- [ ] Home画面初回表示の体感改善を確認
- [ ] スクロール中のカクつき低減を確認
- [ ] ダーク/ライト切替で表示崩れがないことを確認

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)