### PR TITLE
feat(work-detail): あらすじ品質ガード（長さ制御・文体統一・NGフィルタ）

### DIFF
--- a/Sources/App/Services/SummaryQualityGuard.swift
+++ b/Sources/App/Services/SummaryQualityGuard.swift
@@ -1,0 +1,124 @@
+import Foundation
+
+struct SummaryQualityGuard: Sendable {
+    enum Result: Sendable, Equatable {
+        case valid(String)
+        case rejected
+    }
+
+    static let lengthRange = 120 ... 220
+    static let fallbackSuffix = "……"
+
+    private static let ngPatterns: [String] = [
+        "死ぬ", "死んだ", "殺す", "殺される", "殺された",
+        "犯人は", "真犯人", "正体は", "ネタバレ",
+        "結末は", "最後に.*死", "実は.*だった",
+    ]
+
+    private static let desumasuPatterns: [String] = [
+        "です[。、）)]", "ます[。、）)]", "ません", "でした[。、）)]",
+        "ました[。、）)]", "でしょう", "ましょう",
+    ]
+
+    private static let dearuPatterns: [String] = [
+        "である[。、）)]", "であった[。、）)]", "ではない", "であろう",
+        "だった[。、）)]", "ている[。、）)]", "られる[。、）)]",
+    ]
+
+    func validate(_ text: String) -> Result {
+        let cleaned = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !cleaned.isEmpty else { return .rejected }
+
+        if containsNGPattern(cleaned) {
+            return .rejected
+        }
+
+        let adjusted = adjustLength(cleaned)
+        let unified = unifyStyle(adjusted)
+        return .valid(unified)
+    }
+
+    private func containsNGPattern(_ text: String) -> Bool {
+        for pattern in Self.ngPatterns {
+            if
+                let regex = try? NSRegularExpression(pattern: pattern),
+                regex.firstMatch(in: text, range: NSRange(text.startIndex..., in: text)) != nil
+            {
+                return true
+            }
+        }
+        return false
+    }
+
+    private func adjustLength(_ text: String) -> String {
+        if text.count > Self.lengthRange.upperBound {
+            let endIdx = text.index(text.startIndex, offsetBy: Self.lengthRange.upperBound - Self.fallbackSuffix.count)
+            let truncated = String(text[..<endIdx])
+            let trimmed = truncateAtSentenceBoundary(truncated)
+            return trimmed + Self.fallbackSuffix
+        }
+        return text
+    }
+
+    private func truncateAtSentenceBoundary(_ text: String) -> String {
+        let sentenceEndings: [Character] = ["。", "、", "」", "）"]
+        if let lastIdx = text.lastIndex(where: { sentenceEndings.contains($0) }) {
+            let candidate = String(text[...lastIdx])
+            if candidate.count >= Self.lengthRange.lowerBound / 2 {
+                return candidate
+            }
+        }
+        return text
+    }
+
+    private func unifyStyle(_ text: String) -> String {
+        let desumasuCount = countMatches(text, patterns: Self.desumasuPatterns)
+        let dearuCount = countMatches(text, patterns: Self.dearuPatterns)
+
+        guard desumasuCount > 0, dearuCount > 0 else { return text }
+
+        if desumasuCount >= dearuCount {
+            return convertToDesumasu(text)
+        } else {
+            return convertToDearu(text)
+        }
+    }
+
+    private func countMatches(_ text: String, patterns: [String]) -> Int {
+        var count = 0
+        for pattern in patterns {
+            if let regex = try? NSRegularExpression(pattern: pattern) {
+                count += regex.numberOfMatches(in: text, range: NSRange(text.startIndex..., in: text))
+            }
+        }
+        return count
+    }
+
+    private func convertToDesumasu(_ text: String) -> String {
+        var result = text
+        result = replacePattern(result, pattern: "である(。)", with: "です$1")
+        result = replacePattern(result, pattern: "であった(。)", with: "でした$1")
+        result = replacePattern(result, pattern: "ではない", with: "ではありません")
+        result = replacePattern(result, pattern: "であろう", with: "でしょう")
+        return result
+    }
+
+    private func convertToDearu(_ text: String) -> String {
+        var result = text
+        result = replacePattern(result, pattern: "です(。)", with: "である$1")
+        result = replacePattern(result, pattern: "でした(。)", with: "であった$1")
+        result = replacePattern(result, pattern: "ではありません", with: "ではない")
+        result = replacePattern(result, pattern: "でしょう", with: "であろう")
+        result = replacePattern(result, pattern: "ました(。)", with: "た$1")
+        return result
+    }
+
+    private func replacePattern(_ text: String, pattern: String, with replacement: String) -> String {
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return text }
+        return regex.stringByReplacingMatches(
+            in: text,
+            range: NSRange(text.startIndex..., in: text),
+            withTemplate: replacement
+        )
+    }
+}

--- a/Tests/SummaryQualityGuardTests.swift
+++ b/Tests/SummaryQualityGuardTests.swift
@@ -1,0 +1,128 @@
+@testable import App
+import Foundation
+import Testing
+
+@Suite("SummaryQualityGuard 品質検証")
+struct SummaryQualityGuardTests {
+    private let qualityGuard = SummaryQualityGuard()
+
+    // MARK: - Length Control
+
+    @Test("短文: 120文字未満でもそのまま返す")
+    func shortTextPassesThrough() {
+        let text = String(repeating: "あ", count: 80)
+        let result = qualityGuard.validate(text)
+        #expect(result == .valid(text))
+    }
+
+    @Test("範囲内: 120〜220文字はそのまま返す")
+    func withinRangePassesThrough() {
+        let text = String(repeating: "あ", count: 150)
+        let result = qualityGuard.validate(text)
+        #expect(result == .valid(text))
+    }
+
+    @Test("長文: 220文字超は切り詰め+省略記号")
+    func longTextIsTruncated() {
+        let text = String(repeating: "あ", count: 300)
+        if case let .valid(cleaned) = qualityGuard.validate(text) {
+            #expect(cleaned.count <= SummaryQualityGuard.lengthRange.upperBound)
+            #expect(cleaned.hasSuffix("……"))
+        } else {
+            Issue.record("Expected .valid result")
+        }
+    }
+
+    @Test("長文: 句点位置で切り詰め")
+    func longTextTruncatesAtSentenceBoundary() {
+        let prefix = String(repeating: "あ", count: 150) + "。"
+        let suffix = String(repeating: "い", count: 100)
+        let text = prefix + suffix
+        if case let .valid(cleaned) = qualityGuard.validate(text) {
+            #expect(cleaned.contains("。"))
+            #expect(cleaned.count <= SummaryQualityGuard.lengthRange.upperBound)
+        } else {
+            Issue.record("Expected .valid result")
+        }
+    }
+
+    // MARK: - NG Pattern Guard
+
+    @Test("NG: 犯人は を含む文は拒否される")
+    func rejectsHanninPattern() {
+        let text = String(repeating: "あ", count: 100) + "犯人は太郎だった。" + String(repeating: "い", count: 50)
+        #expect(qualityGuard.validate(text) == .rejected)
+    }
+
+    @Test("NG: ネタバレ を含む文は拒否される")
+    func rejectsNetabarePattern() {
+        let text = String(repeating: "あ", count: 100) + "ネタバレ注意" + String(repeating: "い", count: 50)
+        #expect(qualityGuard.validate(text) == .rejected)
+    }
+
+    @Test("NG: 殺された を含む文は拒否される")
+    func rejectsKorosaretePattern() {
+        let text = String(repeating: "あ", count: 100) + "主人公は殺された。" + String(repeating: "い", count: 50)
+        #expect(qualityGuard.validate(text) == .rejected)
+    }
+
+    @Test("NG: 正体は を含む文は拒否される")
+    func rejectsShotaiPattern() {
+        let text = String(repeating: "あ", count: 100) + "彼の正体は実は" + String(repeating: "い", count: 50)
+        #expect(qualityGuard.validate(text) == .rejected)
+    }
+
+    @Test("安全: NGパターン非含有はそのまま返す")
+    func safeTextPasses() {
+        let text = "青年は故郷を離れ、東京の大学に通い始める。都会の喧騒の中で、新しい友人や恩師との出会いを通じて成長していく物語です。彼の日常は穏やかに過ぎていくが、やがて大きな転機が訪れることになる。"
+        if case .valid = qualityGuard.validate(text) {
+            // pass
+        } else {
+            Issue.record("Expected .valid result")
+        }
+    }
+
+    // MARK: - Style Unification
+
+    @Test("文体統一: です/ます優勢時にであるを変換")
+    func unifiesStyleToDesumasu() {
+        let text = "これは物語です。主人公は旅に出ます。しかし彼は孤独である。最後に帰還しました。青春の日々を描いた名作です。読者を魅了する美しい文体です。"
+        if case let .valid(cleaned) = qualityGuard.validate(text) {
+            #expect(!cleaned.contains("である。"))
+        } else {
+            Issue.record("Expected .valid result")
+        }
+    }
+
+    @Test("文体統一: である優勢時にです/ますを変換")
+    func unifiesStyleToDearu() {
+        let text = "これは物語である。主人公は旅に出る。しかし彼は孤独である。彼の旅路は困難であった。だが希望もある。しかし展開は悲しいです。最後の場面は印象的であった。"
+        if case let .valid(cleaned) = qualityGuard.validate(text) {
+            #expect(!cleaned.contains("です。"))
+        } else {
+            Issue.record("Expected .valid result")
+        }
+    }
+
+    @Test("文体統一: 混在なしはそのまま返す")
+    func noMixedStylePassesThrough() {
+        let text = "これは物語である。主人公は旅に出た。しかし彼は孤独であった。帰還した彼は静かに暮らしている。その日々は穏やかであった。彼の人生は波乱に満ちたものであった。"
+        if case let .valid(cleaned) = qualityGuard.validate(text) {
+            #expect(cleaned == text)
+        } else {
+            Issue.record("Expected .valid result")
+        }
+    }
+
+    // MARK: - Edge Cases
+
+    @Test("空文字は拒否される")
+    func emptyTextIsRejected() {
+        #expect(qualityGuard.validate("") == .rejected)
+    }
+
+    @Test("空白のみは拒否される")
+    func whitespaceOnlyIsRejected() {
+        #expect(qualityGuard.validate("   \n\t  ") == .rejected)
+    }
+}


### PR DESCRIPTION
## Summary
- `SummaryQualityGuard` を新設し、あらすじの品質を3軸で制御
  - **長さ制御**: 120〜220文字に収まるよう句点位置で切り詰め+省略記号
  - **文体統一**: です/ます・である混在を検出し、優勢な文体に自動変換
  - **NGガード**: ネタバレ・不適切語句のパターン検出時にフォールバック文を表示
- `SummaryService` の全3ソース（固定JSON / SwiftDataキャッシュ / テキスト生成）にガード適用

## Test plan
- [x] 短文・範囲内・長文の文字数制御テスト（4件）
- [x] NGパターン検出テスト（4件）
- [x] 文体統一テスト（3件）
- [x] エッジケーステスト（空文字・空白のみ）（2件）
- [x] 安全なテキストの通過テスト（1件）
- [x] 全14件パス確認済み

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)