### PR TITLE
feat(ui): customize tab bar branding and icons

### DIFF
--- a/Sources/App/ContentView.swift
+++ b/Sources/App/ContentView.swift
@@ -1,13 +1,16 @@
+import SwiftData
 import SwiftUI
 
 struct ContentView: View {
+    @Query private var favorites: [FavoriteBook]
+
     var body: some View {
         TabView {
             NavigationStack {
                 HomeScreen()
             }
             .tabItem {
-                Label("ホーム", systemImage: "house.fill")
+                Label("ホーム", systemImage: "books.vertical.fill")
             }
 
             NavigationStack {
@@ -21,8 +24,10 @@ struct ContentView: View {
                 FavoritesScreen()
             }
             .tabItem {
-                Label("お気に入り", systemImage: "heart.fill")
+                Label("お気に入り", systemImage: "bookmark.fill")
             }
+            .badge(favorites.count)
         }
+        .tint(AppColors.accent)
     }
 }

--- a/Sources/Features/Home/View/HomeScreen.swift
+++ b/Sources/Features/Home/View/HomeScreen.swift
@@ -23,7 +23,8 @@ struct HomeScreen: View {
             .padding(.vertical)
             .animation(.easeOut(duration: 0.3), value: viewModel.isLoading)
         }
-        .navigationTitle("ホーム")
+        .navigationTitle("青空リーダー")
+        .toolbarTitleDisplayMode(.inlineLarge)
         .navigationDestination(for: Book.self) { book in
             WorkDetailScreen(book: book)
         }


### PR DESCRIPTION
## Summary
- タブバーにアプリのアクセントカラー（`.tint(AppColors.accent)`）を適用
- タブアイコンを変更: ホーム→`books.vertical.fill`、お気に入り→`bookmark.fill`
- お気に入り件数をバッジ表示（SwiftData `@Query` で自動更新）
- ホーム画面のナビゲーションタイトルを「青空リーダー」に変更

## Changes
- `ContentView.swift`: TabView に `.tint()` 追加、アイコン変更、`@Query` でバッジ表示
- `HomeScreen.swift`: ナビゲーションタイトルをブランド名に変更

## Test plan
- [ ] ライト/ダークモードでタブバーが適切に表示されること
- [ ] アクティブタブがアクセントカラーで表示されること
- [ ] お気に入り追加/削除でバッジ数が正しく更新されること
- [ ] ホーム画面のタイトルが「青空リーダー」と表示されること

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)